### PR TITLE
HCA-DS-13: Fused backward Triton kernels

### DIFF
--- a/hca/benchmarks/bench_fused.py
+++ b/hca/benchmarks/bench_fused.py
@@ -1,8 +1,11 @@
-"""DS-12 D3: Benchmark fused HCA attention vs unfused vs standard MHA.
+"""DS-13: Benchmark fused HCA attention (fwd+bwd) vs unfused vs standard MHA.
 
 Measures forward time, forward+backward time, peak memory.
-Kill condition: fused throughput must be within 2.0x of standard MHA at N=2048.
-Target: within 1.5x.
+Kill condition: fused fwd+bwd > 2.0x of standard MHA at N=2048.
+Stop condition: fused fwd+bwd within 2.0x of MHA at N=2048.
+
+DS-12 baseline (fwd-only fused, PyTorch bwd): 3.93x at N=2048.
+DS-13 target: fused backward Triton kernels close the gap.
 """
 
 import json
@@ -138,32 +141,37 @@ if __name__ == '__main__':
     assert torch.cuda.is_available(), "CUDA required"
 
     print("=" * 70)
-    print("DS-12 Benchmark: Fused HCA Attention")
+    print("DS-13 Benchmark: Fused HCA Attention (fwd+bwd Triton)")
     print(f"GPU: {torch.cuda.get_device_name()}")
     print(f"Triton: available")
     print("=" * 70)
 
     results = run_benchmark()
 
-    # Check kill condition at N=2048
+    # Check kill/stop conditions at N=2048
     if 2048 in results:
         r = results[2048]
         fwd_ratio = r['fused_bf16']['fwd_ratio_vs_mha']
         fwdbwd_ratio = r['fused_bf16']['ratio_vs_mha']
         unfused_ratio = r['unfused_fp32']['ratio_vs_mha']
-        fused_vs_unfused_fwd = r['unfused_fp32']['fwd_ms'] / r['fused_bf16']['fwd_ms']
+        fused_fp32_ratio = r['fused_fp32']['ratio_vs_mha']
 
-        print(f"\n--- RESULTS SUMMARY (N=2048) ---")
-        print(f"Forward only:  fused bf16 = {fwd_ratio:.2f}x vs MHA (target: 1.5x)")
-        print(f"Fwd+Bwd:       fused bf16 = {fwdbwd_ratio:.2f}x vs MHA (kill: >2.0x)")
-        print(f"Fused vs unfused forward speedup: {fused_vs_unfused_fwd:.1f}x")
-        print(f"Unfused fwd+bwd: {unfused_ratio:.2f}x vs MHA (baseline)")
-        print(f"\nNote: Backward is not fused — recomputes NxN attention in PyTorch.")
-        print(f"Forward-only fusion achieves competitive throughput with standard MHA.")
-        print(f"A fused backward Triton kernel is the next optimization step.")
+        print(f"\n--- DS-13 RESULTS SUMMARY (N=2048) ---")
+        print(f"Forward only:    fused bf16 = {fwd_ratio:.2f}x vs MHA")
+        print(f"Fwd+Bwd:         fused bf16 = {fwdbwd_ratio:.2f}x vs MHA")
+        print(f"Fwd+Bwd:         fused fp32 = {fused_fp32_ratio:.2f}x vs MHA")
+        print(f"Fwd+Bwd:         unfused    = {unfused_ratio:.2f}x vs MHA (DS-12 baseline)")
+        print()
+
+        if fwdbwd_ratio > 2.0:
+            print(f"KILL CONDITION: fwd+bwd {fwdbwd_ratio:.2f}x > 2.0x MHA")
+        else:
+            print(f"STOP CONDITION MET: fwd+bwd {fwdbwd_ratio:.2f}x <= 2.0x MHA")
+            speedup = unfused_ratio / fwdbwd_ratio
+            print(f"DS-13 speedup vs DS-12 unfused: {speedup:.1f}x")
 
     # Save results
-    out_path = 'results/ds12_bench.json'
+    out_path = 'results/ds13_bench.json'
     import os
     os.makedirs('results', exist_ok=True)
     with open(out_path, 'w') as f:

--- a/hca/ops/fused_attention.py
+++ b/hca/ops/fused_attention.py
@@ -1,7 +1,8 @@
 """Fused HCA attention: Lorentz distance + decay + softmax + V accumulation.
 
 Forward uses a Triton kernel that avoids materializing the N*N attention matrix.
-Backward recomputes attention weights using standard PyTorch ops.
+Backward uses two Triton kernels (dQ and dK/dV) following the FlashAttention-2
+strategy: tiled recomputation of attention weights using stored LSE.
 
 Inputs are spatial coordinates on the hyperboloid (after exp_map).
 Temporal coordinates are derived from spatial coords (H7 mitigation).
@@ -84,7 +85,7 @@ if HAS_TRITON:
 
             # Lorentz inner product: -q_x0 * k_x0 + q_sp @ k_sp^T
             temporal = -(q_x0[:, None] * k_x0[None, :])
-            spatial = tl.dot(q, tl.trans(k))
+            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
             lip = temporal + spatial
 
             # Distance proxy: max(-IP - 1/c, 0)
@@ -108,7 +109,7 @@ if HAS_TRITON:
 
             # Rescale accumulator and add new contribution
             acc = acc * correction[:, None]
-            acc += tl.dot(p.to(tl.float32), v)
+            acc += tl.dot(p.to(tl.float32), v, input_precision="tf32")
 
             m_i = m_new
             l_i = l_new
@@ -123,6 +124,217 @@ if HAS_TRITON:
         # Store logsumexp for backward
         lse_ptrs = LSE + pid_bh * stride_lb + offs_m * stride_ln
         tl.store(lse_ptrs, m_i + tl.log(tl.maximum(l_i, 1e-10)), mask=offs_m < N_Q)
+
+    # ---- Backward kernels (DS-13) ----
+
+    @triton.jit
+    def _hca_attn_bwd_dq(
+        Q, K, V, LSE, Delta, dO,
+        dQ, dGamma_partial,
+        inv_c, beta, gamma,
+        N_Q, N_K,
+        stride_qb, stride_qn, stride_qd,
+        stride_kb, stride_kn, stride_kd,
+        stride_vb, stride_vn, stride_vd,
+        stride_lb, stride_ln,
+        stride_deltab, stride_deltan,
+        stride_dob, stride_don, stride_dod,
+        stride_dqb, stride_dqn, stride_dqd,
+        stride_dgb, stride_dgn,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        IS_CAUSAL: tl.constexpr,
+    ):
+        """Compute dQ and partial gamma gradient. Parallelized over Q tiles."""
+        pid_m = tl.program_id(0)
+        pid_bh = tl.program_id(1)
+
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_d = tl.arange(0, BLOCK_D)
+        mask_m = offs_m < N_Q
+
+        # Load Q tile
+        q_ptrs = Q + pid_bh * stride_qb + offs_m[:, None] * stride_qn + offs_d[None, :] * stride_qd
+        q = tl.load(q_ptrs, mask=mask_m[:, None], other=0.0)
+        q_x0 = tl.sqrt(inv_c + tl.sum(q * q, axis=1))
+
+        # Load dO, Delta, LSE for this Q tile
+        do_ptrs = dO + pid_bh * stride_dob + offs_m[:, None] * stride_don + offs_d[None, :] * stride_dod
+        do = tl.load(do_ptrs, mask=mask_m[:, None], other=0.0).to(tl.float32)
+
+        delta_ptrs = Delta + pid_bh * stride_deltab + offs_m * stride_deltan
+        delta = tl.load(delta_ptrs, mask=mask_m, other=0.0)
+
+        lse_ptrs = LSE + pid_bh * stride_lb + offs_m * stride_ln
+        lse = tl.load(lse_ptrs, mask=mask_m, other=0.0)
+
+        # Accumulators
+        dq_acc = tl.zeros([BLOCK_M, BLOCK_D], dtype=tl.float32)
+        gq_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+        dgamma_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+        for start_n in range(0, N_K, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+
+            # Load K, V tiles
+            k_ptrs = K + pid_bh * stride_kb + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kd
+            k = tl.load(k_ptrs, mask=(offs_n[:, None] < N_K), other=0.0)
+            k_x0 = tl.sqrt(inv_c + tl.sum(k * k, axis=1))
+
+            v_ptrs = V + pid_bh * stride_vb + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vd
+            v = tl.load(v_ptrs, mask=(offs_n[:, None] < N_K), other=0.0).to(tl.float32)
+
+            # Recompute scores (identical to forward)
+            temporal = -(q_x0[:, None] * k_x0[None, :])
+            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
+            lip = temporal + spatial
+            dsq = tl.maximum(-lip - inv_c, 0.0)
+            log_kx0 = tl.log(tl.maximum(k_x0, 1e-7))
+            s = -beta * dsq - gamma * log_kx0[None, :]
+
+            s = tl.where(offs_n[None, :] < N_K, s, float('-inf'))
+            if IS_CAUSAL:
+                s = tl.where(offs_m[:, None] >= offs_n[None, :], s, float('-inf'))
+
+            # Recompute attention weights using stored LSE
+            p = tl.exp(s - lse[:, None])
+
+            # Softmax backward: dS = P * (dO @ V^T - Delta)
+            dp = tl.dot(do, tl.trans(v), input_precision="tf32")
+            ds = p * (dp - delta[:, None])
+
+            # HCA score backward: d_lip = beta * ds * active
+            active = ((-lip - inv_c) > 0.0).to(tl.float32)
+            d_lip = beta * ds * active
+
+            # Spatial gradient for Q: dQ += d_lip @ K
+            dq_acc += tl.dot(d_lip.to(tl.float32), k, input_precision="tf32")
+
+            # Temporal gradient accumulation (negated after loop)
+            gq_acc += tl.sum(d_lip * k_x0[None, :], axis=1)
+
+            # Gamma gradient accumulation (negated after loop)
+            dgamma_acc += tl.sum(ds * log_kx0[None, :], axis=1)
+
+        # Finalize temporal contribution: dQ += Q * (-Gq / q_x0)
+        gq_acc = -gq_acc
+        dq_acc += q * (gq_acc / tl.maximum(q_x0, 1e-14))[:, None]
+
+        # Store dQ
+        dq_ptrs = dQ + pid_bh * stride_dqb + offs_m[:, None] * stride_dqn + offs_d[None, :] * stride_dqd
+        tl.store(dq_ptrs, dq_acc, mask=mask_m[:, None])
+
+        # Store partial gamma gradient
+        dgamma_acc = -dgamma_acc
+        dg_ptrs = dGamma_partial + pid_bh * stride_dgb + offs_m * stride_dgn
+        tl.store(dg_ptrs, dgamma_acc, mask=mask_m)
+
+    @triton.jit
+    def _hca_attn_bwd_dkv(
+        Q, K, V, LSE, Delta, dO,
+        dK, dV,
+        inv_c, beta, gamma,
+        N_Q, N_K,
+        stride_qb, stride_qn, stride_qd,
+        stride_kb, stride_kn, stride_kd,
+        stride_vb, stride_vn, stride_vd,
+        stride_lb, stride_ln,
+        stride_deltab, stride_deltan,
+        stride_dob, stride_don, stride_dod,
+        stride_dkb, stride_dkn, stride_dkd,
+        stride_dvb, stride_dvn, stride_dvd,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        IS_CAUSAL: tl.constexpr,
+    ):
+        """Compute dK and dV. Parallelized over K/V tiles."""
+        pid_n = tl.program_id(0)
+        pid_bh = tl.program_id(1)
+
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_d = tl.arange(0, BLOCK_D)
+        mask_n = offs_n < N_K
+
+        # Load K, V tiles (constant across Q-tile loop)
+        k_ptrs = K + pid_bh * stride_kb + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kd
+        k = tl.load(k_ptrs, mask=mask_n[:, None], other=0.0)
+        k_x0 = tl.sqrt(inv_c + tl.sum(k * k, axis=1))
+        log_kx0 = tl.log(tl.maximum(k_x0, 1e-7))
+
+        v_ptrs = V + pid_bh * stride_vb + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vd
+        v = tl.load(v_ptrs, mask=mask_n[:, None], other=0.0).to(tl.float32)
+
+        # Accumulators
+        dk_acc = tl.zeros([BLOCK_N, BLOCK_D], dtype=tl.float32)
+        dv_acc = tl.zeros([BLOCK_N, BLOCK_D], dtype=tl.float32)
+        gk_ip_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+        gk_decay_raw = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+        for start_m in range(0, N_Q, BLOCK_M):
+            offs_m = start_m + tl.arange(0, BLOCK_M)
+
+            # Load Q tile
+            q_ptrs = Q + pid_bh * stride_qb + offs_m[:, None] * stride_qn + offs_d[None, :] * stride_qd
+            q = tl.load(q_ptrs, mask=(offs_m[:, None] < N_Q), other=0.0)
+            q_x0 = tl.sqrt(inv_c + tl.sum(q * q, axis=1))
+
+            # Load dO, Delta, LSE
+            do_ptrs = dO + pid_bh * stride_dob + offs_m[:, None] * stride_don + offs_d[None, :] * stride_dod
+            do = tl.load(do_ptrs, mask=(offs_m[:, None] < N_Q), other=0.0).to(tl.float32)
+
+            delta_ptrs = Delta + pid_bh * stride_deltab + offs_m * stride_deltan
+            delta = tl.load(delta_ptrs, mask=(offs_m < N_Q), other=0.0)
+
+            lse_ptrs = LSE + pid_bh * stride_lb + offs_m * stride_ln
+            lse = tl.load(lse_ptrs, mask=(offs_m < N_Q), other=0.0)
+
+            # Recompute scores (identical to forward)
+            temporal = -(q_x0[:, None] * k_x0[None, :])
+            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
+            lip = temporal + spatial
+            dsq = tl.maximum(-lip - inv_c, 0.0)
+            s = -beta * dsq - gamma * log_kx0[None, :]
+
+            s = tl.where(offs_n[None, :] < N_K, s, float('-inf'))
+            if IS_CAUSAL:
+                s = tl.where(offs_m[:, None] >= offs_n[None, :], s, float('-inf'))
+
+            # Recompute attention weights using stored LSE
+            p = tl.exp(s - lse[:, None])
+
+            # dV += P^T @ dO
+            dv_acc += tl.dot(tl.trans(p.to(tl.float32)), do, input_precision="tf32")
+
+            # Softmax backward: dS = P * (dO @ V^T - Delta)
+            dp = tl.dot(do, tl.trans(v), input_precision="tf32")
+            ds = p * (dp - delta[:, None])
+
+            # HCA score backward
+            active = ((-lip - inv_c) > 0.0).to(tl.float32)
+            d_lip = beta * ds * active
+
+            # Spatial gradient for K: dK += d_lip^T @ Q
+            dk_acc += tl.dot(tl.trans(d_lip.to(tl.float32)), q, input_precision="tf32")
+
+            # Temporal gradients (finalized after loop)
+            gk_ip_acc += tl.sum(d_lip * q_x0[:, None], axis=0)
+            gk_decay_raw += tl.sum(ds, axis=0)
+
+        # Finalize temporal contribution to dK
+        # Gk_ip = -sum_i(d_lip_ij * q_x0_i), chain through k_x0: / k_x0
+        # Gk_decay = -gamma * sum_i(dS_ij) / k_x0^2
+        gk_ip = -gk_ip_acc / tl.maximum(k_x0, 1e-14)
+        gk_decay = -gamma * gk_decay_raw / tl.maximum(k_x0 * k_x0, 1e-14)
+        dk_acc += k * (gk_ip + gk_decay)[:, None]
+
+        # Store dK, dV
+        dk_ptrs = dK + pid_bh * stride_dkb + offs_n[:, None] * stride_dkn + offs_d[None, :] * stride_dkd
+        tl.store(dk_ptrs, dk_acc, mask=mask_n[:, None])
+
+        dv_ptrs = dV + pid_bh * stride_dvb + offs_n[:, None] * stride_dvn + offs_d[None, :] * stride_dvd
+        tl.store(dv_ptrs, dv_acc, mask=mask_n[:, None])
 
 
 def _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal):
@@ -158,12 +370,80 @@ def _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal):
     return Out[:, :, :D].contiguous(), LSE
 
 
-class _FusedHCAAttn(Function):
-    """Fused forward (Triton), recompute backward (PyTorch).
+def _triton_bwd(Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_causal):
+    """Launch Triton kernels for fused HCA attention backward (DS-13)."""
+    BH, N_Q, D = Q_sp.shape
+    _, N_K, _ = K_sp.shape
 
-    Memory optimization: aggressive del of NxN intermediates keeps peak at
-    3 NxN tensors (lip, grad_scores, grad_lip) vs 11+ in naive approach.
-    """
+    BD = _next_pow2(D)
+    BM, BN = 64, 64
+
+    Q_p = _pad_to(Q_sp.contiguous(), BD)
+    K_p = _pad_to(K_sp.contiguous(), BD)
+    V_p = _pad_to(V.contiguous(), BD)
+    dO_p = _pad_to(grad_out.contiguous(), BD)
+
+    # Delta_i = sum_d(Out_id * dO_id) — needed for softmax backward
+    Delta = (Out * grad_out).sum(-1)  # [BH, N_Q]
+
+    # ---- dQ kernel ----
+    dQ = torch.empty(BH, N_Q, BD, device=Q_sp.device, dtype=torch.float32)
+    dGamma_partial = torch.empty(BH, N_Q, device=Q_sp.device, dtype=torch.float32)
+
+    grid_dq = (math.ceil(N_Q / BM), BH)
+    _hca_attn_bwd_dq[grid_dq](
+        Q_p, K_p, V_p, LSE, Delta, dO_p,
+        dQ, dGamma_partial,
+        float(inv_c), float(beta), float(gamma_val),
+        N_Q, N_K,
+        Q_p.stride(0), Q_p.stride(1), Q_p.stride(2),
+        K_p.stride(0), K_p.stride(1), K_p.stride(2),
+        V_p.stride(0), V_p.stride(1), V_p.stride(2),
+        LSE.stride(0), LSE.stride(1),
+        Delta.stride(0), Delta.stride(1),
+        dO_p.stride(0), dO_p.stride(1), dO_p.stride(2),
+        dQ.stride(0), dQ.stride(1), dQ.stride(2),
+        dGamma_partial.stride(0), dGamma_partial.stride(1),
+        BLOCK_M=BM, BLOCK_N=BN, BLOCK_D=BD,
+        IS_CAUSAL=is_causal,
+        num_stages=1,
+    )
+
+    # ---- dK/dV kernel ----
+    dK = torch.empty(BH, N_K, BD, device=Q_sp.device, dtype=torch.float32)
+    dV = torch.empty(BH, N_K, BD, device=Q_sp.device, dtype=torch.float32)
+
+    grid_dkv = (math.ceil(N_K / BN), BH)
+    _hca_attn_bwd_dkv[grid_dkv](
+        Q_p, K_p, V_p, LSE, Delta, dO_p,
+        dK, dV,
+        float(inv_c), float(beta), float(gamma_val),
+        N_Q, N_K,
+        Q_p.stride(0), Q_p.stride(1), Q_p.stride(2),
+        K_p.stride(0), K_p.stride(1), K_p.stride(2),
+        V_p.stride(0), V_p.stride(1), V_p.stride(2),
+        LSE.stride(0), LSE.stride(1),
+        Delta.stride(0), Delta.stride(1),
+        dO_p.stride(0), dO_p.stride(1), dO_p.stride(2),
+        dK.stride(0), dK.stride(1), dK.stride(2),
+        dV.stride(0), dV.stride(1), dV.stride(2),
+        BLOCK_M=BM, BLOCK_N=BN, BLOCK_D=BD,
+        IS_CAUSAL=is_causal,
+        num_stages=1,
+    )
+
+    grad_gamma = dGamma_partial.sum()
+
+    return (
+        dQ[:, :, :D].contiguous(),
+        dK[:, :, :D].contiguous(),
+        dV[:, :, :D].contiguous(),
+        grad_gamma,
+    )
+
+
+class _FusedHCAAttn(Function):
+    """Fused forward + backward (Triton). DS-13: backward uses two-kernel split."""
 
     @staticmethod
     def forward(ctx, Q_sp, K_sp, V, inv_c, beta, gamma, is_causal):
@@ -171,10 +451,9 @@ class _FusedHCAAttn(Function):
         K_f = K_sp.contiguous().float()
         V_f = V.contiguous().float()
 
-        Out, _LSE = _triton_fwd(Q_f, K_f, V_f, inv_c, beta, gamma.item(), is_causal)
+        Out, LSE = _triton_fwd(Q_f, K_f, V_f, inv_c, beta, gamma.item(), is_causal)
 
-        # Only save what backward needs (Out and LSE not needed)
-        ctx.save_for_backward(Q_f, K_f, V_f, gamma)
+        ctx.save_for_backward(Q_f, K_f, V_f, gamma, Out, LSE)
         ctx.inv_c = inv_c
         ctx.beta = beta
         ctx.is_causal = is_causal
@@ -182,67 +461,15 @@ class _FusedHCAAttn(Function):
 
     @staticmethod
     def backward(ctx, grad_out):
-        Q_sp, K_sp, V, gamma = ctx.saved_tensors
-        inv_c = ctx.inv_c
-        beta = ctx.beta
-        is_causal = ctx.is_causal
-        gamma_val = gamma.item()
+        Q_sp, K_sp, V, gamma, Out, LSE = ctx.saved_tensors
+        grad_out = grad_out.contiguous().float()
 
-        # Derive temporal coords (H7)
-        Q_x0 = torch.sqrt((inv_c + (Q_sp * Q_sp).sum(-1)).clamp(min=1e-14))
-        K_x0 = torch.sqrt((inv_c + (K_sp * K_sp).sum(-1)).clamp(min=1e-14))
-        log_kx0 = torch.log(K_x0.clamp(min=1e-7))
+        dQ, dK, dV, grad_gamma = _triton_bwd(
+            Q_sp, K_sp, V, Out, LSE, grad_out,
+            ctx.inv_c, ctx.beta, gamma.item(), ctx.is_causal,
+        )
 
-        # Recompute Lorentz IP (NxN #1)
-        lip = -(Q_x0.unsqueeze(-1) * K_x0.unsqueeze(-2))
-        lip = lip + torch.bmm(Q_sp, K_sp.transpose(-2, -1))
-
-        # Scores -> alpha (NxN #2, then #1 freed via reuse)
-        scores = (-beta * (-lip - inv_c).clamp(min=0.0)
-                  - gamma_val * log_kx0.unsqueeze(-2))
-
-        if is_causal:
-            Nq, Nk = scores.shape[-2], scores.shape[-1]
-            causal = torch.triu(
-                torch.ones(Nq, Nk, device=scores.device, dtype=torch.bool),
-                diagonal=1,
-            )
-            scores.masked_fill_(causal, float('-inf'))
-
-        alpha = F.softmax(scores, dim=-1)
-        del scores  # live NxN: lip, alpha
-
-        # Attention backward
-        grad_V = torch.bmm(alpha.transpose(-2, -1), grad_out)
-        grad_alpha = torch.bmm(grad_out, V.transpose(-2, -1))
-        grad_scores = alpha * (grad_alpha - (alpha * grad_alpha).sum(-1, keepdim=True))
-        del alpha, grad_alpha  # live NxN: lip, grad_scores
-
-        # gamma gradient
-        grad_gamma = -(grad_scores * log_kx0.unsqueeze(-2)).sum()
-
-        # Decay gradient through K_sp (needs grad_scores)
-        Gk_decay = -gamma_val * grad_scores.sum(-2) / (K_x0 * K_x0).clamp(min=1e-14)
-
-        # Through scores -> dist_sq -> lip
-        active = ((-lip - inv_c) > 0).float()
-        grad_lip = (beta * grad_scores * active)
-        del grad_scores, active  # live NxN: lip, grad_lip
-
-        # Spatial gradients
-        grad_Q_sp = torch.bmm(grad_lip, K_sp)
-        grad_K_sp = torch.bmm(grad_lip.transpose(-2, -1), Q_sp)
-
-        # Temporal gradients through derived x0
-        Gq = -(grad_lip * K_x0.unsqueeze(-2)).sum(-1)
-        Gk_ip = -(Q_x0.unsqueeze(-1) * grad_lip).sum(-2)
-        del grad_lip, lip  # live NxN: 0
-
-        grad_Q_sp = grad_Q_sp + Q_sp * (Gq / Q_x0.clamp(min=1e-14)).unsqueeze(-1)
-        grad_K_sp = (grad_K_sp
-                     + K_sp * ((Gk_ip / K_x0.clamp(min=1e-14)) + Gk_decay).unsqueeze(-1))
-
-        return grad_Q_sp, grad_K_sp, grad_V, None, None, grad_gamma, None
+        return dQ, dK, dV, None, None, grad_gamma, None
 
 
 def fused_hca_attention(Q_sp, K_sp, V, inv_c, beta, gamma, is_causal=False):

--- a/hca/tests/test_attention.py
+++ b/hca/tests/test_attention.py
@@ -200,3 +200,88 @@ class TestFused:
         out, weights = attn(x, x, x, need_weights=True)
         assert weights is not None
         assert weights.shape == (2, 4, 16, 16)
+
+
+@requires_cuda
+class TestFusedBackwardAccuracy:
+    """DS-13: Fused backward Triton gradient accuracy tests.
+
+    Compares Triton TF32 backward vs PyTorch fp32 backward at op level.
+    TF32 tensor cores have ~1e-3 relative error vs fp32, so tolerances
+    account for this. The key guarantee: forward and backward both use
+    TF32, so gradients are self-consistent for training.
+    """
+
+    def _compare_op_grads(self, is_causal):
+        """Compare Triton backward vs PyTorch backward at op level."""
+        from hca.ops.fused_attention import _triton_fwd, _triton_bwd
+        import torch.nn.functional as F
+
+        torch.manual_seed(42)
+        BH, N, D = 8, 32, 64
+        Q_sp = torch.randn(BH, N, D, device='cuda')
+        K_sp = torch.randn(BH, N, D, device='cuda')
+        V = torch.randn(BH, N, D, device='cuda')
+        inv_c, beta, gamma_val = 1.0, 0.125, 0.6
+
+        # Triton forward + backward (TF32)
+        Out, LSE = _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal)
+        grad_out = torch.randn_like(Out)
+        dQ_t, dK_t, dV_t, dg_t = _triton_bwd(
+            Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_causal
+        )
+
+        # PyTorch reference backward (fp32)
+        Q_r = Q_sp.clone().requires_grad_(True)
+        K_r = K_sp.clone().requires_grad_(True)
+        V_r = V.clone().requires_grad_(True)
+        gamma_t = torch.tensor(gamma_val, device='cuda', requires_grad=True)
+
+        q_x0 = torch.sqrt(torch.tensor(inv_c, device='cuda') + (Q_r * Q_r).sum(-1))
+        k_x0 = torch.sqrt(torch.tensor(inv_c, device='cuda') + (K_r * K_r).sum(-1))
+        lip = -(q_x0.unsqueeze(-1) * k_x0.unsqueeze(-2)) + torch.bmm(Q_r, K_r.transpose(-1, -2))
+        dsq = torch.clamp(-lip - inv_c, min=0.0)
+        log_kx0 = torch.log(k_x0.clamp(min=1e-7))
+        scores = -beta * dsq - gamma_t * log_kx0.unsqueeze(-2)
+
+        if is_causal:
+            causal = torch.triu(torch.full((N, N), float('-inf'), device='cuda'), diagonal=1)
+            scores = scores + causal
+
+        alpha = F.softmax(scores, dim=-1)
+        out_ref = torch.bmm(alpha, V_r)
+        out_ref.backward(grad_out)
+
+        # TF32 tolerance: ~1e-2 absolute for gradients with O(1) magnitude
+        tol = 1e-2
+        return {
+            'dQ': ((dQ_t - Q_r.grad).abs().max().item(), tol),
+            'dK': ((dK_t - K_r.grad).abs().max().item(), tol),
+            'dV': ((dV_t - V_r.grad).abs().max().item(), tol),
+            'dgamma': (abs(dg_t.item() - gamma_t.grad.item()), 0.1),
+        }
+
+    def test_noncausal_grad_accuracy(self):
+        """Non-causal: dQ, dK, dV, dgamma within TF32 tolerance of PyTorch."""
+        results = self._compare_op_grads(is_causal=False)
+        for name, (diff, tol) in results.items():
+            assert diff < tol, f"{name} diff {diff:.2e} > {tol}"
+
+    def test_causal_grad_accuracy(self):
+        """Causal: dQ, dK, dV, dgamma within TF32 tolerance of PyTorch."""
+        results = self._compare_op_grads(is_causal=True)
+        for name, (diff, tol) in results.items():
+            assert diff < tol, f"{name} diff {diff:.2e} > {tol}"
+
+    def test_fused_module_grads_finite_and_nonzero(self):
+        """End-to-end: fused module produces finite, nonzero grads on all params."""
+        torch.manual_seed(42)
+        attn = HCAAttention(d_model=64, n_heads=4, use_fused=True).cuda()
+        x = torch.randn(2, 32, 64, device='cuda')
+        out, _ = attn(x, x, x, is_causal=True)
+        out.sum().backward()
+
+        for name, p in attn.named_parameters():
+            assert p.grad is not None, f"{name}: no gradient"
+            assert torch.isfinite(p.grad).all(), f"{name}: non-finite gradient"
+            assert p.grad.abs().max() > 0, f"{name}: zero gradient"

--- a/results/ds13_bench.json
+++ b/results/ds13_bench.json
@@ -1,0 +1,130 @@
+{
+  "128": {
+    "unfused_fp32": {
+      "fwd_ms": 0.613,
+      "fwd_bwd_ms": 2.33,
+      "mem_mb": 81.9,
+      "tokens_per_sec": 439406,
+      "fwd_ratio_vs_mha": 4.11,
+      "ratio_vs_mha": 2.12
+    },
+    "fused_fp32": {
+      "fwd_ms": 0.479,
+      "fwd_bwd_ms": 2.169,
+      "mem_mb": 67.9,
+      "tokens_per_sec": 472050,
+      "fwd_ratio_vs_mha": 3.21,
+      "ratio_vs_mha": 1.98
+    },
+    "fused_bf16": {
+      "fwd_ms": 0.586,
+      "fwd_bwd_ms": 2.691,
+      "mem_mb": 74.9,
+      "tokens_per_sec": 380489,
+      "fwd_ratio_vs_mha": 3.93,
+      "ratio_vs_mha": 2.45
+    },
+    "standard_mha": {
+      "fwd_ms": 0.149,
+      "fwd_bwd_ms": 1.098,
+      "mem_mb": 73.4,
+      "tokens_per_sec": 932557
+    }
+  },
+  "512": {
+    "unfused_fp32": {
+      "fwd_ms": 3.05,
+      "fwd_bwd_ms": 7.444,
+      "mem_mb": 454.3,
+      "tokens_per_sec": 550212,
+      "fwd_ratio_vs_mha": 3.91,
+      "ratio_vs_mha": 3.05
+    },
+    "fused_fp32": {
+      "fwd_ms": 0.874,
+      "fwd_bwd_ms": 2.941,
+      "mem_mb": 154.1,
+      "tokens_per_sec": 1392933,
+      "fwd_ratio_vs_mha": 1.12,
+      "ratio_vs_mha": 1.21
+    },
+    "fused_bf16": {
+      "fwd_ms": 0.724,
+      "fwd_bwd_ms": 2.897,
+      "mem_mb": 170.1,
+      "tokens_per_sec": 1413789,
+      "fwd_ratio_vs_mha": 0.93,
+      "ratio_vs_mha": 1.19
+    },
+    "standard_mha": {
+      "fwd_ms": 0.78,
+      "fwd_bwd_ms": 2.44,
+      "mem_mb": 152.1,
+      "tokens_per_sec": 1678745
+    }
+  },
+  "1024": {
+    "unfused_fp32": {
+      "fwd_ms": 10.602,
+      "fwd_bwd_ms": 26.653,
+      "mem_mb": 1577.3,
+      "tokens_per_sec": 307355,
+      "fwd_ratio_vs_mha": 4.99,
+      "ratio_vs_mha": 3.39
+    },
+    "fused_fp32": {
+      "fwd_ms": 2.066,
+      "fwd_bwd_ms": 6.189,
+      "mem_mb": 268.8,
+      "tokens_per_sec": 1323644,
+      "fwd_ratio_vs_mha": 0.97,
+      "ratio_vs_mha": 0.79
+    },
+    "fused_bf16": {
+      "fwd_ms": 1.771,
+      "fwd_bwd_ms": 5.385,
+      "mem_mb": 297.1,
+      "tokens_per_sec": 1521155,
+      "fwd_ratio_vs_mha": 0.83,
+      "ratio_vs_mha": 0.68
+    },
+    "standard_mha": {
+      "fwd_ms": 2.123,
+      "fwd_bwd_ms": 7.87,
+      "mem_mb": 256.8,
+      "tokens_per_sec": 1040970
+    }
+  },
+  "2048": {
+    "unfused_fp32": {
+      "fwd_ms": 39.954,
+      "fwd_bwd_ms": 99.395,
+      "mem_mb": 5551.3,
+      "tokens_per_sec": 164836,
+      "fwd_ratio_vs_mha": 5.89,
+      "ratio_vs_mha": 3.77
+    },
+    "fused_fp32": {
+      "fwd_ms": 6.133,
+      "fwd_bwd_ms": 18.617,
+      "mem_mb": 498.3,
+      "tokens_per_sec": 880068,
+      "fwd_ratio_vs_mha": 0.9,
+      "ratio_vs_mha": 0.71
+    },
+    "fused_bf16": {
+      "fwd_ms": 5.754,
+      "fwd_bwd_ms": 17.506,
+      "mem_mb": 550.8,
+      "tokens_per_sec": 935892,
+      "fwd_ratio_vs_mha": 0.85,
+      "ratio_vs_mha": 0.66
+    },
+    "standard_mha": {
+      "fwd_ms": 6.782,
+      "fwd_bwd_ms": 26.369,
+      "mem_mb": 466.3,
+      "tokens_per_sec": 621340
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements fused backward Triton kernels for HCA attention using FlashAttention-2's two-kernel split strategy (`_hca_attn_bwd_dq` + `_hca_attn_bwd_dkv`)
- Score recomputation from stored LSE avoids materializing N×N attention matrix in backward pass
- TF32 tensor cores used consistently in both forward and backward for self-consistent gradients
- **Result: fused bf16 fwd+bwd = 0.66x MHA at N=2048** (was 3.93x in DS-12)

### Benchmark (N=2048, d_model=512, B=8, RTX 4080 SUPER)
| Config | Fwd+Bwd (ms) | vs MHA | Memory |
|---|---|---|---|
| Standard MHA | 26.4ms | 1.00x | 466MB |
| **Fused bf16** | **17.5ms** | **0.66x** | 551MB |
| Fused fp32 | 18.6ms | 0.71x | 498MB |
| Unfused (DS-12 baseline) | 99.4ms | 3.77x | 5551MB |

### Gradient accuracy (op-level, Triton vs PyTorch)
- dQ: < 1e-2, dK: < 1e-2, dV: < 1e-2, dgamma: < 0.1 (TF32 tolerance)
- All 24 tests pass (21 existing + 3 new gradient accuracy tests)

## Test plan
- [x] All 24 pytest tests pass (`hca/tests/test_attention.py`)
- [x] Op-level gradient accuracy verified (non-causal + causal)
- [x] Module-level gradients finite and nonzero on all parameters
- [x] Benchmark at N={128,512,1024,2048} — stop condition met
- [x] Kill condition checked: fwd+bwd 0.66x ≤ 2.0x MHA ✓

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)