### PR TITLE
HCA-DS-13: Parameterize dot precision for tight gradient tests

### DIFF
--- a/hca/ops/fused_attention.py
+++ b/hca/ops/fused_attention.py
@@ -50,6 +50,7 @@ if HAS_TRITON:
         BLOCK_N: tl.constexpr,
         BLOCK_D: tl.constexpr,
         IS_CAUSAL: tl.constexpr,
+        DOT_PRECISION: tl.constexpr = "tf32",
     ):
         pid_m = tl.program_id(0)
         pid_bh = tl.program_id(1)
@@ -85,7 +86,7 @@ if HAS_TRITON:
 
             # Lorentz inner product: -q_x0 * k_x0 + q_sp @ k_sp^T
             temporal = -(q_x0[:, None] * k_x0[None, :])
-            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
+            spatial = tl.dot(q, tl.trans(k), input_precision=DOT_PRECISION)
             lip = temporal + spatial
 
             # Distance proxy: max(-IP - 1/c, 0)
@@ -109,7 +110,7 @@ if HAS_TRITON:
 
             # Rescale accumulator and add new contribution
             acc = acc * correction[:, None]
-            acc += tl.dot(p.to(tl.float32), v, input_precision="tf32")
+            acc += tl.dot(p.to(tl.float32), v, input_precision=DOT_PRECISION)
 
             m_i = m_new
             l_i = l_new
@@ -145,6 +146,7 @@ if HAS_TRITON:
         BLOCK_N: tl.constexpr,
         BLOCK_D: tl.constexpr,
         IS_CAUSAL: tl.constexpr,
+        DOT_PRECISION: tl.constexpr = "tf32",
     ):
         """Compute dQ and partial gamma gradient. Parallelized over Q tiles."""
         pid_m = tl.program_id(0)
@@ -187,7 +189,7 @@ if HAS_TRITON:
 
             # Recompute scores (identical to forward)
             temporal = -(q_x0[:, None] * k_x0[None, :])
-            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
+            spatial = tl.dot(q, tl.trans(k), input_precision=DOT_PRECISION)
             lip = temporal + spatial
             dsq = tl.maximum(-lip - inv_c, 0.0)
             log_kx0 = tl.log(tl.maximum(k_x0, 1e-7))
@@ -201,7 +203,7 @@ if HAS_TRITON:
             p = tl.exp(s - lse[:, None])
 
             # Softmax backward: dS = P * (dO @ V^T - Delta)
-            dp = tl.dot(do, tl.trans(v), input_precision="tf32")
+            dp = tl.dot(do, tl.trans(v), input_precision=DOT_PRECISION)
             ds = p * (dp - delta[:, None])
 
             # HCA score backward: d_lip = beta * ds * active
@@ -209,7 +211,7 @@ if HAS_TRITON:
             d_lip = beta * ds * active
 
             # Spatial gradient for Q: dQ += d_lip @ K
-            dq_acc += tl.dot(d_lip.to(tl.float32), k, input_precision="tf32")
+            dq_acc += tl.dot(d_lip.to(tl.float32), k, input_precision=DOT_PRECISION)
 
             # Temporal gradient accumulation (negated after loop)
             gq_acc += tl.sum(d_lip * k_x0[None, :], axis=1)
@@ -248,6 +250,7 @@ if HAS_TRITON:
         BLOCK_N: tl.constexpr,
         BLOCK_D: tl.constexpr,
         IS_CAUSAL: tl.constexpr,
+        DOT_PRECISION: tl.constexpr = "tf32",
     ):
         """Compute dK and dV. Parallelized over K/V tiles."""
         pid_n = tl.program_id(0)
@@ -292,7 +295,7 @@ if HAS_TRITON:
 
             # Recompute scores (identical to forward)
             temporal = -(q_x0[:, None] * k_x0[None, :])
-            spatial = tl.dot(q, tl.trans(k), input_precision="tf32")
+            spatial = tl.dot(q, tl.trans(k), input_precision=DOT_PRECISION)
             lip = temporal + spatial
             dsq = tl.maximum(-lip - inv_c, 0.0)
             s = -beta * dsq - gamma * log_kx0[None, :]
@@ -305,10 +308,10 @@ if HAS_TRITON:
             p = tl.exp(s - lse[:, None])
 
             # dV += P^T @ dO
-            dv_acc += tl.dot(tl.trans(p.to(tl.float32)), do, input_precision="tf32")
+            dv_acc += tl.dot(tl.trans(p.to(tl.float32)), do, input_precision=DOT_PRECISION)
 
             # Softmax backward: dS = P * (dO @ V^T - Delta)
-            dp = tl.dot(do, tl.trans(v), input_precision="tf32")
+            dp = tl.dot(do, tl.trans(v), input_precision=DOT_PRECISION)
             ds = p * (dp - delta[:, None])
 
             # HCA score backward
@@ -316,7 +319,7 @@ if HAS_TRITON:
             d_lip = beta * ds * active
 
             # Spatial gradient for K: dK += d_lip^T @ Q
-            dk_acc += tl.dot(tl.trans(d_lip.to(tl.float32)), q, input_precision="tf32")
+            dk_acc += tl.dot(tl.trans(d_lip.to(tl.float32)), q, input_precision=DOT_PRECISION)
 
             # Temporal gradients (finalized after loop)
             gk_ip_acc += tl.sum(d_lip * q_x0[:, None], axis=0)
@@ -337,7 +340,8 @@ if HAS_TRITON:
         tl.store(dv_ptrs, dv_acc, mask=mask_n[:, None])
 
 
-def _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal):
+def _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal,
+                dot_precision="tf32"):
     """Launch Triton kernel for fused HCA attention forward."""
     BH, N_Q, D = Q_sp.shape
     _, N_K, _ = K_sp.shape
@@ -365,12 +369,14 @@ def _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal):
         LSE.stride(0), LSE.stride(1),
         BLOCK_M=BM, BLOCK_N=BN, BLOCK_D=BD,
         IS_CAUSAL=is_causal,
+        DOT_PRECISION=dot_precision,
     )
 
     return Out[:, :, :D].contiguous(), LSE
 
 
-def _triton_bwd(Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_causal):
+def _triton_bwd(Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val,
+                is_causal, dot_precision="tf32"):
     """Launch Triton kernels for fused HCA attention backward (DS-13)."""
     BH, N_Q, D = Q_sp.shape
     _, N_K, _ = K_sp.shape
@@ -406,6 +412,7 @@ def _triton_bwd(Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_ca
         dGamma_partial.stride(0), dGamma_partial.stride(1),
         BLOCK_M=BM, BLOCK_N=BN, BLOCK_D=BD,
         IS_CAUSAL=is_causal,
+        DOT_PRECISION=dot_precision,
         num_stages=1,
     )
 
@@ -429,6 +436,7 @@ def _triton_bwd(Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_ca
         dV.stride(0), dV.stride(1), dV.stride(2),
         BLOCK_M=BM, BLOCK_N=BN, BLOCK_D=BD,
         IS_CAUSAL=is_causal,
+        DOT_PRECISION=dot_precision,
         num_stages=1,
     )
 

--- a/hca/tests/test_attention.py
+++ b/hca/tests/test_attention.py
@@ -206,14 +206,14 @@ class TestFused:
 class TestFusedBackwardAccuracy:
     """DS-13: Fused backward Triton gradient accuracy tests.
 
-    Compares Triton TF32 backward vs PyTorch fp32 backward at op level.
-    TF32 tensor cores have ~1e-3 relative error vs fp32, so tolerances
-    account for this. The key guarantee: forward and backward both use
-    TF32, so gradients are self-consistent for training.
+    Uses dot_precision="ieee" for both Triton forward and backward so that
+    tl.dot uses full fp32 — enabling tight comparison against PyTorch fp32
+    reference without TF32 noise. Production uses "tf32" for speed; these
+    tests verify the backward MATH is correct.
     """
 
     def _compare_op_grads(self, is_causal):
-        """Compare Triton backward vs PyTorch backward at op level."""
+        """Compare Triton ieee backward vs PyTorch fp32 backward at op level."""
         from hca.ops.fused_attention import _triton_fwd, _triton_bwd
         import torch.nn.functional as F
 
@@ -224,11 +224,15 @@ class TestFusedBackwardAccuracy:
         V = torch.randn(BH, N, D, device='cuda')
         inv_c, beta, gamma_val = 1.0, 0.125, 0.6
 
-        # Triton forward + backward (TF32)
-        Out, LSE = _triton_fwd(Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal)
+        # Triton forward + backward (ieee = full fp32 dot products)
+        Out, LSE = _triton_fwd(
+            Q_sp, K_sp, V, inv_c, beta, gamma_val, is_causal,
+            dot_precision="ieee",
+        )
         grad_out = torch.randn_like(Out)
         dQ_t, dK_t, dV_t, dg_t = _triton_bwd(
-            Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val, is_causal
+            Q_sp, K_sp, V, Out, LSE, grad_out, inv_c, beta, gamma_val,
+            is_causal, dot_precision="ieee",
         )
 
         # PyTorch reference backward (fp32)
@@ -252,23 +256,23 @@ class TestFusedBackwardAccuracy:
         out_ref = torch.bmm(alpha, V_r)
         out_ref.backward(grad_out)
 
-        # TF32 tolerance: ~1e-2 absolute for gradients with O(1) magnitude
-        tol = 1e-2
+        # Tight fp32 tolerance: ieee Triton should match PyTorch closely
+        tol = 1e-4
         return {
             'dQ': ((dQ_t - Q_r.grad).abs().max().item(), tol),
             'dK': ((dK_t - K_r.grad).abs().max().item(), tol),
             'dV': ((dV_t - V_r.grad).abs().max().item(), tol),
-            'dgamma': (abs(dg_t.item() - gamma_t.grad.item()), 0.1),
+            'dgamma': (abs(dg_t.item() - gamma_t.grad.item()), 1e-3),
         }
 
     def test_noncausal_grad_accuracy(self):
-        """Non-causal: dQ, dK, dV, dgamma within TF32 tolerance of PyTorch."""
+        """Non-causal: dQ, dK, dV, dgamma match PyTorch fp32 within 1e-4."""
         results = self._compare_op_grads(is_causal=False)
         for name, (diff, tol) in results.items():
             assert diff < tol, f"{name} diff {diff:.2e} > {tol}"
 
     def test_causal_grad_accuracy(self):
-        """Causal: dQ, dK, dV, dgamma within TF32 tolerance of PyTorch."""
+        """Causal: dQ, dK, dV, dgamma match PyTorch fp32 within 1e-4."""
         results = self._compare_op_grads(is_causal=True)
         for name, (diff, tol) in results.items():
             assert diff < tol, f"{name} diff {diff:.2e} > {tol}"


### PR DESCRIPTION
## Summary
- Adds `DOT_PRECISION` constexpr to all three Triton kernels, threaded through `_triton_fwd` / `_triton_bwd` as `dot_precision=`
- Production path unchanged: defaults to `"tf32"` (tensor cores)
- Gradient accuracy tests now use `"ieee"` (full fp32 dots), enabling **1e-4 tolerance** — 100x tighter than the TF32 cross-precision comparison shipped in #60

### Why
The DS-13 gradient tests compared TF32 Triton backward against fp32 PyTorch backward, requiring 1e-2 tolerance to absorb TF32 rounding noise. That tolerance is wide enough to mask real bugs. By running tests in ieee mode, we verify the backward *math* is correct at fp32 precision, decoupled from tensor core approximation.

## Test plan
- [x] 24/24 tests pass
- [x] ieee gradient tests: dQ/dK/dV < 1e-4, dgamma < 1e-3
- [x] Production tf32 path produces identical results (default unchanged)

Follow-up to #60. No Lab Work Item — test infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)