### PR TITLE
Decouple semantic identity from values: first-class slot_labels

### DIFF
--- a/associative_core.py
+++ b/associative_core.py
@@ -179,6 +179,27 @@ class ContinuousCAM(nn.Module):
         """
         return targets.float().argmax(dim=-1).long()
 
+    def effective_slot_labels(self, idx=None) -> torch.Tensor:
+        """Semantic labels for ``idx`` (or all slots), repairing unstamped slots.
+
+        ``slot_labels`` is authoritative, but a slot can be *occupied without a
+        stamped label* (sentinel ``-1``) when buffers are populated directly —
+        manual prepopulation, ``load_state_dict(strict=False)``, or legacy state
+        — instead of through :meth:`learn_local`. For those occupied-but-unstamped
+        slots only, fall back to ``argmax(values)`` (exactly the pre-decoupling
+        behavior) so discrete-index consumers (``one_hot``, ``scatter_add_``,
+        ``max``) never see a negative sentinel and crash. Unoccupied slots are
+        left as ``-1``; callers mask them as before.
+        """
+        labels = self.slot_labels if idx is None else self.slot_labels[idx]
+        occ = self.occupied if idx is None else self.occupied[idx]
+        repair = occ & (labels < 0)
+        if repair.any():
+            vals = self.values if idx is None else self.values[idx]
+            labels = labels.clone()
+            labels[repair] = vals[repair].float().argmax(dim=-1)
+        return labels
+
     # ------------------------------------------------------------------
     # Single-query API (kept for compatibility)
     # ------------------------------------------------------------------
@@ -263,7 +284,7 @@ class ContinuousCAM(nn.Module):
         Sole class representatives get score = inf (protected from eviction).
         """
         keys_norm = self._keys_norm[occupied_idx]
-        class_labels = self.slot_labels[occupied_idx]
+        class_labels = self.effective_slot_labels(occupied_idx)
         scores = torch.full(
             (len(occupied_idx),), float("inf"),
             device=keys_norm.device, dtype=torch.float32,
@@ -290,7 +311,7 @@ class ContinuousCAM(nn.Module):
 
         Score semantics: lower = evict first.
         """
-        class_labels = self.slot_labels[occupied_idx]
+        class_labels = self.effective_slot_labels(occupied_idx)
         unique_classes, class_counts = class_labels.unique(return_counts=True)
         n_classes_present = len(unique_classes)
         n_classes_seen = len(self._classes_ever_seen) if self._classes_ever_seen else n_classes_present
@@ -382,7 +403,7 @@ class ContinuousCAM(nn.Module):
         if _nstp is not None:
             topk_keys = self.keys[topk_slots].float()                         # (B, final_k, key_dim)
             topk_vals = self.values[topk_slots].float()                       # (B, final_k, value_dim)
-            topk_labels = self.slot_labels[topk_slots]                        # (B, final_k)
+            topk_labels = self.effective_slot_labels(topk_slots)                        # (B, final_k)
             keep_mask, _ = _nstp.prune_batch(
                 q_norm.float(), topk_keys, topk_vals, topk_sims,
                 labels=topk_labels,
@@ -523,7 +544,7 @@ class ContinuousCAM(nn.Module):
             keys_occ = self._keys_norm[valid_idx]                # (N_occ, D)
             # Semantic identity comes from the first-class label store, not from
             # argmax over the `values` payload (see _labels_from_targets).
-            proto_labels = self.slot_labels[valid_idx]           # (N_occ,)
+            proto_labels = self.effective_slot_labels(valid_idx)           # (N_occ,)
 
             q_norm = F.normalize(queries.float(), dim=-1)         # (B, D)
             sims_full = q_norm @ keys_occ.T                      # (B, N_occ)
@@ -594,7 +615,7 @@ class ContinuousCAM(nn.Module):
             if self.retrieval_floor_policy is not None and self.occupied.any():
                 valid_idx = self.occupied.nonzero(as_tuple=True)[0]
                 keys_occ = self._keys_norm[valid_idx]
-                proto_labels = self.slot_labels[valid_idx]
+                proto_labels = self.effective_slot_labels(valid_idx)
                 q_norm = F.normalize(queries.float(), dim=-1)
                 sims_wc = q_norm @ keys_occ.T
                 true_labels = self._labels_from_targets(targets)
@@ -698,7 +719,7 @@ class ContinuousCAM(nn.Module):
                 and self.occupied.any()):
             valid_idx = self.occupied.nonzero(as_tuple=True)[0]
             keys_occ = self._keys_norm[valid_idx]
-            proto_labels = self.slot_labels[valid_idx]
+            proto_labels = self.effective_slot_labels(valid_idx)
             q_norm = F.normalize(queries.float(), dim=-1)
             sims_seed = q_norm @ keys_occ.T
             true_labels = self._labels_from_targets(targets)
@@ -725,7 +746,7 @@ class ContinuousCAM(nn.Module):
             return {"epochs": 0, "collisions_initial": 0,
                     "collisions_final": 0, "keys_modified": 0}
 
-        class_labels = self.slot_labels[occ_idx]              # (N_occ,)
+        class_labels = self.effective_slot_labels(occ_idx)              # (N_occ,)
         all_keys_norm = self._keys_norm[occ_idx]              # (N_occ, D)
 
         collisions_initial = None
@@ -909,7 +930,7 @@ class ContinuousCAM(nn.Module):
         valid_idx = self.occupied.nonzero(as_tuple=True)[0]
         keys_occ = self._keys_norm[valid_idx].float()                    # (N, D)
         # Semantic identity from the first-class label store (see _labels_from_targets).
-        proto_labels = self.slot_labels[valid_idx]                       # (N,)
+        proto_labels = self.effective_slot_labels(valid_idx)                       # (N,)
 
         sims = q @ keys_occ.T                                            # (P, N)
         same_class = proto_labels.unsqueeze(0) == labels.unsqueeze(1)    # (P, N)

--- a/associative_core.py
+++ b/associative_core.py
@@ -90,6 +90,15 @@ class ContinuousCAM(nn.Module):
         # Memory storage — all on same device via register_buffer
         self.register_buffer("keys", torch.zeros(max_entries, key_dim, dtype=mem_dtype))
         self.register_buffer("values", torch.zeros(max_entries, value_dim, dtype=mem_dtype))
+        # Per-slot discrete semantic label (AgentAssociativeMemory semantic
+        # decoupling). First-class identity state — keys hold retrieval geometry,
+        # values hold continuous payload, slot_labels hold semantic identity.
+        # Written at learn time via the compatibility writer _labels_from_targets()
+        # so that internal consumers (vigilance, sleep, eviction, telemetry) never
+        # have to re-derive class identity from the `values` payload. -1 = no label
+        # (unoccupied). Discrete LongTensor for now; soft/multi-label schemes can
+        # extend _labels_from_targets — the single, narrow escape hatch.
+        self.register_buffer("slot_labels", torch.full((max_entries,), -1, dtype=torch.long))
         self.register_buffer("occupied", torch.zeros(max_entries, dtype=torch.bool))
         self.register_buffer("last_seen", torch.zeros(max_entries, dtype=torch.float64))
         # Pre-normalized key cache for fast cosine similarity
@@ -156,6 +165,19 @@ class ContinuousCAM(nn.Module):
     def _update_key_norm(self, slots):
         """Update cached normalized keys for given slot indices."""
         self._keys_norm[slots] = F.normalize(self.keys[slots], dim=-1)
+
+    def _labels_from_targets(self, targets: torch.Tensor) -> torch.Tensor:
+        """Compatibility label writer: derive discrete slot labels from targets.
+
+        This is the *single* narrow point where semantic identity is inferred
+        from value-space vectors. The default — argmax over the value dimension —
+        reproduces the legacy one-hot / orthogonal-prototype classification
+        behavior exactly for a freshly written slot, so existing image/classifier
+        callers are unchanged. Future soft- or multi-label schemes should extend
+        or replace this method rather than re-introducing ``values.argmax()`` at
+        call sites; the rest of the engine reads ``self.slot_labels`` instead.
+        """
+        return targets.float().argmax(dim=-1).long()
 
     # ------------------------------------------------------------------
     # Single-query API (kept for compatibility)
@@ -241,7 +263,7 @@ class ContinuousCAM(nn.Module):
         Sole class representatives get score = inf (protected from eviction).
         """
         keys_norm = self._keys_norm[occupied_idx]
-        class_labels = self.values[occupied_idx].float().argmax(dim=-1)
+        class_labels = self.slot_labels[occupied_idx]
         scores = torch.full(
             (len(occupied_idx),), float("inf"),
             device=keys_norm.device, dtype=torch.float32,
@@ -268,7 +290,7 @@ class ContinuousCAM(nn.Module):
 
         Score semantics: lower = evict first.
         """
-        class_labels = self.values[occupied_idx].float().argmax(dim=-1)
+        class_labels = self.slot_labels[occupied_idx]
         unique_classes, class_counts = class_labels.unique(return_counts=True)
         n_classes_present = len(unique_classes)
         n_classes_seen = len(self._classes_ever_seen) if self._classes_ever_seen else n_classes_present
@@ -360,8 +382,10 @@ class ContinuousCAM(nn.Module):
         if _nstp is not None:
             topk_keys = self.keys[topk_slots].float()                         # (B, final_k, key_dim)
             topk_vals = self.values[topk_slots].float()                       # (B, final_k, value_dim)
+            topk_labels = self.slot_labels[topk_slots]                        # (B, final_k)
             keep_mask, _ = _nstp.prune_batch(
-                q_norm.float(), topk_keys, topk_vals, topk_sims
+                q_norm.float(), topk_keys, topk_vals, topk_sims,
+                labels=topk_labels,
             )
             topk_sims = topk_sims.masked_fill(~keep_mask, -float("inf"))
 
@@ -497,11 +521,9 @@ class ContinuousCAM(nn.Module):
         if self.dynamic_vigilance is not None and self.occupied.any():
             valid_idx = self.occupied.nonzero(as_tuple=True)[0]
             keys_occ = self._keys_norm[valid_idx]                # (N_occ, D)
-            # TD(AgentAssociativeMemory): argmax assumes one-hot / softmax-class
-            # value vectors. Works for the current classifier/probe branch but will
-            # not generalise to dense arbitrary-value slots. The refactor should
-            # introduce an explicit label store or a pluggable label extractor.
-            proto_labels = self.values[valid_idx].float().argmax(dim=-1)  # (N_occ,)
+            # Semantic identity comes from the first-class label store, not from
+            # argmax over the `values` payload (see _labels_from_targets).
+            proto_labels = self.slot_labels[valid_idx]           # (N_occ,)
 
             q_norm = F.normalize(queries.float(), dim=-1)         # (B, D)
             sims_full = q_norm @ keys_occ.T                      # (B, N_occ)
@@ -557,7 +579,7 @@ class ContinuousCAM(nn.Module):
             # Within-class Δ estimate for the retrieval floor policy (issue #74),
             # reusing the sims_full / proto_labels already computed here.
             if self.retrieval_floor_policy is not None:
-                true_labels = targets.float().argmax(dim=-1)
+                true_labels = self._labels_from_targets(targets)
                 within_class_sims = self._within_class_loo(
                     sims_full, proto_labels, true_labels)
             else:
@@ -572,10 +594,10 @@ class ContinuousCAM(nn.Module):
             if self.retrieval_floor_policy is not None and self.occupied.any():
                 valid_idx = self.occupied.nonzero(as_tuple=True)[0]
                 keys_occ = self._keys_norm[valid_idx]
-                proto_labels = self.values[valid_idx].float().argmax(dim=-1)
+                proto_labels = self.slot_labels[valid_idx]
                 q_norm = F.normalize(queries.float(), dim=-1)
                 sims_wc = q_norm @ keys_occ.T
-                true_labels = targets.float().argmax(dim=-1)
+                true_labels = self._labels_from_targets(targets)
                 within_class_sims = self._within_class_loo(
                     sims_wc, proto_labels, true_labels)
 
@@ -655,6 +677,9 @@ class ContinuousCAM(nn.Module):
             n_alloc = len(new_slots)
             self.keys[new_slots] = miss_queries[:n_alloc]
             self.values[new_slots] = miss_targets[:n_alloc]
+            # Stamp semantic identity at write time (compat writer). Reused
+            # eviction victims get their stale label overwritten here.
+            self.slot_labels[new_slots] = self._labels_from_targets(miss_targets[:n_alloc])
             self.occupied[new_slots] = True
             self.last_seen[new_slots] = now
             self.usage[new_slots] = 1
@@ -673,17 +698,17 @@ class ContinuousCAM(nn.Module):
                 and self.occupied.any()):
             valid_idx = self.occupied.nonzero(as_tuple=True)[0]
             keys_occ = self._keys_norm[valid_idx]
-            proto_labels = self.values[valid_idx].float().argmax(dim=-1)
+            proto_labels = self.slot_labels[valid_idx]
             q_norm = F.normalize(queries.float(), dim=-1)
             sims_seed = q_norm @ keys_occ.T
-            true_labels = targets.float().argmax(dim=-1)
+            true_labels = self._labels_from_targets(targets)
             seed_sims = self._within_class_loo(sims_seed, proto_labels, true_labels)
             if seed_sims.numel() > 0:
                 self.retrieval_floor_policy.update(seed_sims)
 
         # Track all classes seen for adaptive eviction (covers hits + misses)
         if self.adaptive_eviction:
-            all_classes = targets.float().argmax(dim=-1)
+            all_classes = self._labels_from_targets(targets)
             self._classes_ever_seen.update(all_classes.cpu().tolist())
 
     def sleep(self, anti_lr=0.3, max_epochs=10, collision_threshold=0.5,
@@ -700,7 +725,7 @@ class ContinuousCAM(nn.Module):
             return {"epochs": 0, "collisions_initial": 0,
                     "collisions_final": 0, "keys_modified": 0}
 
-        class_labels = self.values[occ_idx].argmax(dim=-1)   # (N_occ,)
+        class_labels = self.slot_labels[occ_idx]              # (N_occ,)
         all_keys_norm = self._keys_norm[occ_idx]              # (N_occ, D)
 
         collisions_initial = None
@@ -883,8 +908,8 @@ class ContinuousCAM(nn.Module):
 
         valid_idx = self.occupied.nonzero(as_tuple=True)[0]
         keys_occ = self._keys_norm[valid_idx].float()                    # (N, D)
-        # TD(AgentAssociativeMemory): same argmax assumption as in learn_local().
-        proto_labels = self.values[valid_idx].float().argmax(dim=-1)     # (N,)
+        # Semantic identity from the first-class label store (see _labels_from_targets).
+        proto_labels = self.slot_labels[valid_idx]                       # (N,)
 
         sims = q @ keys_occ.T                                            # (P, N)
         same_class = proto_labels.unsqueeze(0) == labels.unsqueeze(1)    # (P, N)

--- a/fast_associative_memory.py
+++ b/fast_associative_memory.py
@@ -211,7 +211,8 @@ class FastAssociativeMemory(nn.Module):
         else:
             rej_slots = tr.rejected_slots.clamp(min=0, max=core.max_entries - 1)
             occupied_mask = core.occupied[rej_slots]                        # (B, rej_k)
-            rej_classes = core.values[rej_slots].float().argmax(dim=-1)     # (B, rej_k)
+            rej_classes = core.slot_labels[rej_slots]                       # (B, rej_k)
+            # Unoccupied slots carry label -1; mask them to 0 before one_hot.
             rej_classes = rej_classes.masked_fill(~occupied_mask, 0)
             rej_one_hot = F.one_hot(rej_classes, n_classes).float()         # (B, rej_k, nc)
             rej_hists = (

--- a/fast_associative_memory.py
+++ b/fast_associative_memory.py
@@ -211,8 +211,11 @@ class FastAssociativeMemory(nn.Module):
         else:
             rej_slots = tr.rejected_slots.clamp(min=0, max=core.max_entries - 1)
             occupied_mask = core.occupied[rej_slots]                        # (B, rej_k)
-            rej_classes = core.slot_labels[rej_slots]                       # (B, rej_k)
-            # Unoccupied slots carry label -1; mask them to 0 before one_hot.
+            # effective_slot_labels repairs occupied-but-unstamped slots (label
+            # -1, e.g. directly prepopulated buffers) via argmax(values) so
+            # one_hot never sees a negative index. Unoccupied slots stay -1 and
+            # are masked to 0 below.
+            rej_classes = core.effective_slot_labels(rej_slots)             # (B, rej_k)
             rej_classes = rej_classes.masked_fill(~occupied_mask, 0)
             rej_one_hot = F.one_hot(rej_classes, n_classes).float()         # (B, rej_k, nc)
             rej_hists = (

--- a/nstp.py
+++ b/nstp.py
@@ -40,7 +40,8 @@ class NSTPController:
 
     def prune(self, query: torch.Tensor, keys: torch.Tensor,
               values: torch.Tensor, sims: torch.Tensor,
-              root_vec: torch.Tensor | None = None):
+              root_vec: torch.Tensor | None = None,
+              labels: torch.Tensor | None = None):
         """Apply lateral inhibition to a set of retrieved candidates.
 
         Args:
@@ -51,6 +52,10 @@ class NSTPController:
             root_vec: External root vector for ``'context'`` strategy,
                       shape ``(D,)``.  Ignored when strategy is
                       ``'proximity'``.
+            labels: Optional ``(K,)`` discrete semantic labels for class-aware
+                    suppression. When provided (the decoupled path), identity
+                    comes from the caller's label store; when ``None`` it falls
+                    back to ``values.argmax`` for backward compatibility.
 
         Returns:
             Tuple ``(mask, sims_out)`` where:
@@ -96,8 +101,12 @@ class NSTPController:
         keep = torch.ones(K, dtype=torch.bool, device=keys.device)
 
         if siblings.any():
-            # Get class labels from values for class-aware suppression
-            classes = values.float().argmax(dim=-1)  # (K,)
+            # Class labels for class-aware suppression: prefer the caller's
+            # decoupled label store; fall back to argmax(values) for compat.
+            if labels is not None:
+                classes = labels
+            else:
+                classes = values.float().argmax(dim=-1)  # (K,)
 
             # Only suppress siblings of DIFFERENT classes
             # (same-class siblings should reinforce, not compete)
@@ -133,7 +142,8 @@ class NSTPController:
         return keep, sims_out
 
     def prune_batch(self, queries: torch.Tensor, keys: torch.Tensor,
-                    values: torch.Tensor, sims: torch.Tensor):
+                    values: torch.Tensor, sims: torch.Tensor,
+                    labels: torch.Tensor | None = None):
         """Batched version: applies prune() per query in the batch.
 
         Args:
@@ -141,6 +151,8 @@ class NSTPController:
             keys:    ``(B, K, D)``
             values:  ``(B, K, V)``
             sims:    ``(B, K)``
+            labels:  Optional ``(B, K)`` discrete semantic labels; forwarded
+                     per-row to :meth:`prune`. ``None`` → argmax(values) compat.
 
         Returns:
             Tuple ``(masks, sims_out)`` — both ``(B, K)``.
@@ -150,7 +162,9 @@ class NSTPController:
         sims_out = sims.clone()
 
         for b in range(B):
-            m, s = self.prune(queries[b], keys[b], values[b], sims[b])
+            labels_b = labels[b] if labels is not None else None
+            m, s = self.prune(queries[b], keys[b], values[b], sims[b],
+                              labels=labels_b)
             masks[b] = m
             sims_out[b] = s
 

--- a/shutter_deck/eviction.py
+++ b/shutter_deck/eviction.py
@@ -71,6 +71,13 @@ def alloc_slots_density_aware(
     # back to argmax(values) for backward compatibility when not supplied.
     if slot_labels is not None:
         class_id = slot_labels[occ_idx]  # (N_occ,)
+        # Repair occupied-but-unstamped slots (sentinel -1, e.g. directly
+        # prepopulated buffers) via argmax(values); a negative index would
+        # break class_pop sizing and scatter_add_ below.
+        unstamped = class_id < 0
+        if unstamped.any():
+            class_id = class_id.clone()
+            class_id[unstamped] = values[occ_idx][unstamped].argmax(dim=-1)
     else:
         class_id = values[occ_idx].argmax(dim=-1)  # (N_occ,)
 

--- a/shutter_deck/eviction.py
+++ b/shutter_deck/eviction.py
@@ -20,6 +20,7 @@ def alloc_slots_density_aware(
     values: torch.Tensor,
     max_entries: int,
     min_per_class: int = 5,
+    slot_labels: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Allocate *n* slots using density-aware eviction with class-balanced floors.
 
@@ -66,8 +67,12 @@ def alloc_slots_density_aware(
     if occ_idx.numel() == 0:
         return free[:n]
 
-    # Step 2a: compute class labels from stored value vectors
-    class_id = values[occ_idx].argmax(dim=-1)  # (N_occ,)
+    # Step 2a: semantic labels — prefer the decoupled slot_labels store; fall
+    # back to argmax(values) for backward compatibility when not supplied.
+    if slot_labels is not None:
+        class_id = slot_labels[occ_idx]  # (N_occ,)
+    else:
+        class_id = values[occ_idx].argmax(dim=-1)  # (N_occ,)
 
     # Step 2b: per-class population counts
     # Use scatter to count in a single pass
@@ -137,6 +142,7 @@ def install_density_eviction(cam, min_per_class: int = 5):
             values=self.values,
             max_entries=self.max_entries,
             min_per_class=min_per_class,
+            slot_labels=self.slot_labels,
         )
 
     cam._alloc_slots_batch = types.MethodType(_alloc_slots_batch, cam)

--- a/shutter_deck/persistence.py
+++ b/shutter_deck/persistence.py
@@ -21,7 +21,10 @@ import torch
 logger = logging.getLogger(__name__)
 
 MAGIC = b"FCAM"
-VERSION = 2
+# v3: added slot_labels (int64) — first-class semantic identity decoupled from
+# the `values` payload. v2 files are rejected by the version check and cold-start
+# (existing graceful-fallback contract); a cold start re-stamps labels at write.
+VERSION = 3
 HEADER_FMT = "<4sHIIII"  # magic(4) + version(2) + max_entries(4) + key_dim(4) + value_dim(4) + n_occupied(4)
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
 
@@ -29,6 +32,7 @@ HEADER_SIZE = struct.calcsize(HEADER_FMT)
 _TENSOR_FIELDS = [
     ("keys", np.float32),
     ("values", np.float32),
+    ("slot_labels", np.int64),
     ("occupied", np.bool_),
     ("last_seen", np.float64),
     ("usage", np.float32),

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -50,8 +50,8 @@ class TestSaveLoadRoundTrip:
         assert ok is True
 
         # Check all tensor buffers
-        for name in ["keys", "values", "occupied", "last_seen", "usage",
-                      "_keys_norm", "hit_counts"]:
+        for name in ["keys", "values", "slot_labels", "occupied", "last_seen",
+                      "usage", "_keys_norm", "hit_counts"]:
             orig = getattr(cam, name)
             loaded = getattr(cam2, name)
             assert torch.equal(orig, loaded), f"Mismatch in buffer '{name}'"

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -27,6 +27,9 @@ def cam():
         c.keys[i] = torch.randn(32)
         c.values[i] = torch.randn(8)
         c.occupied[i] = True
+        # Explicit non-sentinel label pattern so the round-trip exercises real
+        # occupied-slot label persistence, not just the -1 default.
+        c.slot_labels[i] = i % 8
         c.last_seen[i] = float(i * 100)
         c.usage[i] = float(i + 1)
         c.hit_counts[i] = i + 1

--- a/tests/test_slot_labels.py
+++ b/tests/test_slot_labels.py
@@ -63,17 +63,68 @@ class TestLabelStability:
 
 class TestDecoupledFromPayload:
     def test_dense_values_do_not_define_identity(self):
-        """With dense (non-one-hot) targets, identity comes from the writer, not
-        from whatever argmax(values) happens to land on later."""
+        """Identity is stamped from the target at write time and does NOT track
+        the payload: mutating values afterward must not change slot_labels."""
         cam = ContinuousCAM(key_dim=16, value_dim=8, max_entries=64, vigilance=0.95)
-        # Orthogonal-style dense targets (argmax position == intended label).
+        # Dense (non-one-hot) targets; all misses → slots 0..2 in input order.
         protos = F.normalize(torch.randn(3, 8), dim=-1)
-        ids = torch.tensor([0, 1, 2])
-        cam.learn_local(torch.randn(3, 16), protos[ids])
+        targets = protos[torch.tensor([0, 1, 2])]
+        cam.learn_local(torch.randn(3, 16), targets)
         occ = cam.occupied.nonzero(as_tuple=True)[0]
-        # Labels are concrete LongTensor entries, present and stable.
-        assert cam.slot_labels[occ].dtype == torch.long
-        assert cam.slot_labels[occ].numel() == 3
+
+        # Labels equal what the compat writer derived from the written targets.
+        expected = cam._labels_from_targets(targets)
+        assert torch.equal(cam.slot_labels[occ], expected)
+
+        # Now scramble the payload. Identity must be unaffected — it lives in
+        # slot_labels, not in argmax(values).
+        before = cam.slot_labels[occ].clone()
+        cam.values[occ] = F.normalize(torch.randn(occ.numel(), 8), dim=-1)
+        assert torch.equal(cam.slot_labels[occ], before)
+
+
+class TestSentinelRepair:
+    """Occupied slots populated WITHOUT learn_local keep label -1; consumers
+    that need a non-negative index must repair them via argmax(values) rather
+    than crash (PR #77 review)."""
+
+    def _prepopulate_unstamped(self, value_dim=6, max_entries=32):
+        cam = ContinuousCAM(key_dim=16, value_dim=value_dim, max_entries=max_entries)
+        # Direct buffer fill — bypasses _labels_from_targets, so slot_labels==-1.
+        n = 8
+        cam.keys[:n] = torch.randn(n, 16)
+        cam.values[:n] = _one_hot(torch.arange(n) % value_dim, value_dim)
+        cam._keys_norm[:n] = F.normalize(cam.keys[:n], dim=-1)
+        cam.occupied[:n] = True
+        assert torch.all(cam.slot_labels[:n] == -1)  # precondition
+        return cam, n
+
+    def test_effective_labels_repairs_occupied_sentinels(self):
+        cam, n = self._prepopulate_unstamped()
+        occ = cam.occupied.nonzero(as_tuple=True)[0]
+        eff = cam.effective_slot_labels(occ)
+        assert torch.all(eff >= 0)
+        assert torch.equal(eff, cam.values[occ].float().argmax(dim=-1))
+        # The underlying buffer is NOT mutated by the read-time repair.
+        assert torch.all(cam.slot_labels[occ] == -1)
+
+    def test_probe_does_not_crash_on_unstamped(self):
+        cam, n = self._prepopulate_unstamped()
+        out = cam.probe_cross_class_similarity(torch.randn(5, 16),
+                                               torch.randint(0, 6, (5,)))
+        assert "n_occupied" in out
+
+    def test_density_eviction_does_not_crash_on_unstamped(self):
+        from shutter_deck.eviction import alloc_slots_density_aware
+        cam, n = self._prepopulate_unstamped(max_entries=8)
+        # Request more than free → forces the eviction path through slot_labels.
+        slots = alloc_slots_density_aware(
+            n=4, occupied=cam.occupied, usage=cam.usage,
+            last_seen=cam.last_seen, values=cam.values,
+            max_entries=cam.max_entries, min_per_class=1,
+            slot_labels=cam.slot_labels,
+        )
+        assert slots.numel() <= 4
 
 
 class TestLifecyclePathsUseLabels:

--- a/tests/test_slot_labels.py
+++ b/tests/test_slot_labels.py
@@ -1,0 +1,101 @@
+"""
+tests/test_slot_labels.py — First-class slot_labels semantic decoupling.
+
+Validates the AgentAssociativeMemory abstraction boundary:
+  - keys        = retrieval geometry
+  - values      = continuous payload vectors
+  - slot_labels = semantic identity (first-class, written at learn time)
+
+Characterizes the compatibility guarantee: for a freshly written slot,
+slot_labels reproduces the legacy argmax(values) label exactly, so existing
+one-hot / orthogonal-prototype classification behavior is unchanged. Also
+proves labels are stable state (not re-derived from the drifting payload) and
+that values can hold arbitrary dense vectors without leaking class identity.
+"""
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from associative_core import ContinuousCAM
+
+
+def _one_hot(classes, n):
+    return F.one_hot(torch.as_tensor(classes), num_classes=n).float()
+
+
+class TestWriteTimeStamping:
+    def test_labels_match_argmax_on_fresh_write(self):
+        """Freshly written slot_labels == legacy argmax(values) — compat guarantee."""
+        cam = ContinuousCAM(key_dim=16, value_dim=5, max_entries=64, vigilance=0.9)
+        classes = torch.tensor([0, 1, 2, 3, 4, 2, 1])
+        cam.learn_local(torch.randn(7, 16), _one_hot(classes, 5))
+
+        occ = cam.occupied.nonzero(as_tuple=True)[0]
+        legacy = cam.values[occ].float().argmax(dim=-1)
+        assert torch.equal(cam.slot_labels[occ], legacy)
+
+    def test_unoccupied_label_is_sentinel(self):
+        cam = ContinuousCAM(key_dim=16, value_dim=5, max_entries=64)
+        assert torch.all(cam.slot_labels == -1)
+        cam.learn_local(torch.randn(3, 16), _one_hot([0, 1, 2], 5))
+        assert torch.all(cam.slot_labels[~cam.occupied] == -1)
+        assert torch.all(cam.slot_labels[cam.occupied] >= 0)
+
+
+class TestLabelStability:
+    def test_label_survives_ema_drift(self):
+        """slot_labels is fixed state; it must not flip as the payload drifts."""
+        cam = ContinuousCAM(key_dim=16, value_dim=4, max_entries=16,
+                            vigilance=0.0, hebb_lr=0.5)  # v=0 → everything hits
+        key = F.normalize(torch.randn(1, 16), dim=-1)
+        cam.learn_local(key, _one_hot([1], 4))
+        slot = cam.occupied.nonzero(as_tuple=True)[0]
+        label0 = cam.slot_labels[slot].clone()
+
+        # Repeatedly hit the same slot with a noisy, non-one-hot target to drag
+        # the payload around. The stored label must stay put.
+        for _ in range(20):
+            noisy = torch.tensor([[0.4, 0.45, 0.1, 0.05]])
+            cam.learn_local(key, noisy)
+        assert torch.equal(cam.slot_labels[slot], label0)
+
+
+class TestDecoupledFromPayload:
+    def test_dense_values_do_not_define_identity(self):
+        """With dense (non-one-hot) targets, identity comes from the writer, not
+        from whatever argmax(values) happens to land on later."""
+        cam = ContinuousCAM(key_dim=16, value_dim=8, max_entries=64, vigilance=0.95)
+        # Orthogonal-style dense targets (argmax position == intended label).
+        protos = F.normalize(torch.randn(3, 8), dim=-1)
+        ids = torch.tensor([0, 1, 2])
+        cam.learn_local(torch.randn(3, 16), protos[ids])
+        occ = cam.occupied.nonzero(as_tuple=True)[0]
+        # Labels are concrete LongTensor entries, present and stable.
+        assert cam.slot_labels[occ].dtype == torch.long
+        assert cam.slot_labels[occ].numel() == 3
+
+
+class TestLifecyclePathsUseLabels:
+    """Smoke: eviction, sleep, and the cross-class probe run off slot_labels."""
+
+    def test_sleep_runs(self):
+        cam = ContinuousCAM(key_dim=16, value_dim=4, max_entries=64, vigilance=0.99)
+        cam.learn_local(torch.randn(20, 16), _one_hot(torch.randint(0, 4, (20,)), 4))
+        out = cam.sleep(max_epochs=2)
+        assert "epochs" in out
+
+    def test_eviction_runs(self):
+        cam = ContinuousCAM(key_dim=16, value_dim=4, max_entries=8,
+                            vigilance=0.99, use_lfu=True, adaptive_eviction=False)
+        # Force allocation past capacity → eviction path reads slot_labels.
+        cam.learn_local(torch.randn(20, 16), _one_hot(torch.randint(0, 4, (20,)), 4))
+        assert cam.occupied.sum().item() <= 8
+
+    def test_probe_runs(self):
+        cam = ContinuousCAM(key_dim=16, value_dim=4, max_entries=64, vigilance=0.9)
+        labels = torch.randint(0, 4, (30,))
+        cam.learn_local(torch.randn(30, 16), _one_hot(labels, 4))
+        out = cam.probe_cross_class_similarity(torch.randn(10, 16),
+                                               torch.randint(0, 4, (10,)))
+        assert "n_occupied" in out


### PR DESCRIPTION
## Summary

First commit of the **AgentAssociativeMemory semantic-decoupling** work. Establishes the abstraction boundary so semantic identity is real state rather than something inferred from the continuous payload:

| concern | owner |
|---|---|
| retrieval geometry | `keys` |
| continuous payload vectors | `values` |
| **semantic identity** | **`slot_labels`** (new) |
| provenance / external records | `slot_records` (deferred) |

`slot_labels` is a first-class `LongTensor` buffer (−1 = unoccupied), stamped at learn time via a single compatibility writer `_labels_from_targets()` (default `argmax(targets)`). That writer is the *only* place identity is inferred from value-space, and the narrow escape hatch for future soft/multi-label schemes. Internal consumers read `slot_labels` instead of re-deriving class identity from the drifting `values` payload.

## Changes

**`associative_core.py`** — add `slot_labels` buffer + `_labels_from_targets()`; write labels at miss-allocation; replace internal `values.argmax()` identity reads in: coverage + adaptive eviction scoring, dynamic-vigilance / retrieval-floor / cold-start-seed paths, `sleep`, `probe_cross_class_similarity`.

**`fast_associative_memory.py`** — RVA rejection histogram reads `slot_labels`.

**`nstp.py`** — `prune`/`prune_batch` gain an optional `labels` param (default `None` → legacy `argmax(values)` fallback); `forward()` passes `slot_labels[topk_slots]`.

**`shutter_deck/eviction.py`** — `alloc_slots_density_aware` gains an optional `slot_labels` param (same fallback); the `install_density_eviction` closure passes `self.slot_labels`.

**`shutter_deck/persistence.py`** — VERSION 2→3, `slot_labels` serialized as int64. v2 files cold-start via the existing graceful-fallback path.

## Compatibility

- Image/classification behavior is **unchanged by default**: for a freshly written slot, `slot_labels == argmax(values)`, and adjacent-module `labels` params default to the old `argmax(values)` path so direct callers/tests are untouched.
- The decoupling makes labels *more* stable than before — they no longer flip if EMA drift moves `argmax(values)`.

## Tests

New `tests/test_slot_labels.py`: write-time stamping equals legacy argmax, label stability under EMA drift, payload decoupling, and lifecycle smoke (eviction/sleep/probe). Full suite: **376 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)