### PR TITLE
Add slot_records: per-slot provenance / write-history layer

### DIFF
--- a/associative_core.py
+++ b/associative_core.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import time
 
+from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Union, Tuple
 
@@ -121,7 +122,7 @@ class ContinuousCAM(nn.Module):
         # does not move with .to(device). Opt-in — None when disabled so the core
         # CAM math and all existing callers are byte-for-byte unchanged.
         self.track_provenance = track_provenance
-        self.slot_records: list | None = (
+        self.slot_records: list[set[Hashable] | None] | None = (
             [None] * max_entries if track_provenance else None)
 
     @property
@@ -221,23 +222,29 @@ class ContinuousCAM(nn.Module):
                 "Provenance is disabled (track_provenance=False). Construct "
                 "ContinuousCAM(track_provenance=True) to record and read it.")
 
-    def records_for(self, slot: int) -> set:
+    def records_for(self, slot: int) -> set[Hashable]:
         """Provenance record set for a single slot (read-only copy).
 
-        Returns an empty set for unoccupied/unstamped slots. Requires
-        ``track_provenance=True``.
+        Returns an empty set for unoccupied/unstamped slots and for the ``-1``
+        trace-padding sentinel (a negative index must NOT wrap to the last
+        slot). Requires ``track_provenance=True``.
         """
         self._require_provenance()
-        rec = self.slot_records[int(slot)]
+        s = int(slot)
+        if s < 0:
+            return set()
+        rec = self.slot_records[s]
         return set(rec) if rec else set()
 
-    def records_for_slots(self, slots) -> list:
+    def records_for_slots(self, slots) -> list[set[Hashable]]:
         """Provenance record sets for an iterable / tensor of slot indices.
 
         Returns a list of sets aligned to ``slots`` (empty where a slot has no
         recorded history). Accepts a :class:`RetrievalTrace`'s ``final_slots`` /
         top-k slot tensor so callers can map retrieved prototypes back to their
-        sources without altering tensor retrieval. Copies are returned so the
+        sources without altering tensor retrieval. The ``-1`` trace-padding
+        sentinel maps to an empty set — a negative index must NOT wrap to the
+        last slot and report another query's sources. Copies are returned so the
         internal history sets cannot be mutated through the accessor. Requires
         ``track_provenance=True``.
         """
@@ -246,7 +253,11 @@ class ContinuousCAM(nn.Module):
             slots = slots.flatten().tolist()
         out = []
         for s in slots:
-            rec = self.slot_records[int(s)]
+            si = int(s)
+            if si < 0:
+                out.append(set())
+                continue
+            rec = self.slot_records[si]
             out.append(set(rec) if rec else set())
         return out
 

--- a/associative_core.py
+++ b/associative_core.py
@@ -49,7 +49,8 @@ class ContinuousCAM(nn.Module):
                  inference_k: int = 20, inference_temp: float = 0.05,
                  ema_beta: float = 0.05,
                  dynamic_vigilance=None,
-                 retrieval_floor_policy=None):
+                 retrieval_floor_policy=None,
+                 track_provenance: bool = False):
         super().__init__()
         self.key_dim = key_dim
         self.value_dim = value_dim
@@ -108,6 +109,20 @@ class ContinuousCAM(nn.Module):
         # Per-slot hit count for adaptive EMA alpha decay
         self.register_buffer("hit_counts", torch.zeros(max_entries, dtype=torch.int32))
         self.nstp = None  # Optional NSTPController for lateral inhibition
+
+        # Per-slot provenance (AgentAssociativeMemory). The fourth layer of the
+        # decoupling: keys=geometry, values=payload, slot_labels=identity,
+        # slot_records=provenance/history. Each entry is the set of external
+        # record IDs whose writes/merges formed that prototype — the ACTUAL
+        # write history, never reconstructed from nearest-prototype assignment.
+        # Records are arbitrary hashables (ints, tuples, strings) so this is a
+        # plain Python list, not a tensor buffer: it is intentionally NOT part of
+        # the binary persistence format (a sidecar is a documented follow-up) and
+        # does not move with .to(device). Opt-in — None when disabled so the core
+        # CAM math and all existing callers are byte-for-byte unchanged.
+        self.track_provenance = track_provenance
+        self.slot_records: list | None = (
+            [None] * max_entries if track_provenance else None)
 
     @property
     def _mem_dtype(self):
@@ -199,6 +214,41 @@ class ContinuousCAM(nn.Module):
             labels = labels.clone()
             labels[repair] = vals[repair].float().argmax(dim=-1)
         return labels
+
+    def _require_provenance(self):
+        if self.slot_records is None:
+            raise RuntimeError(
+                "Provenance is disabled (track_provenance=False). Construct "
+                "ContinuousCAM(track_provenance=True) to record and read it.")
+
+    def records_for(self, slot: int) -> set:
+        """Provenance record set for a single slot (read-only copy).
+
+        Returns an empty set for unoccupied/unstamped slots. Requires
+        ``track_provenance=True``.
+        """
+        self._require_provenance()
+        rec = self.slot_records[int(slot)]
+        return set(rec) if rec else set()
+
+    def records_for_slots(self, slots) -> list:
+        """Provenance record sets for an iterable / tensor of slot indices.
+
+        Returns a list of sets aligned to ``slots`` (empty where a slot has no
+        recorded history). Accepts a :class:`RetrievalTrace`'s ``final_slots`` /
+        top-k slot tensor so callers can map retrieved prototypes back to their
+        sources without altering tensor retrieval. Copies are returned so the
+        internal history sets cannot be mutated through the accessor. Requires
+        ``track_provenance=True``.
+        """
+        self._require_provenance()
+        if isinstance(slots, torch.Tensor):
+            slots = slots.flatten().tolist()
+        out = []
+        for s in slots:
+            rec = self.slot_records[int(s)]
+            out.append(set(rec) if rec else set())
+        return out
 
     # ------------------------------------------------------------------
     # Single-query API (kept for compatibility)
@@ -525,13 +575,33 @@ class ContinuousCAM(nn.Module):
         )
         return outputs, tr
 
-    def learn_local(self, queries: torch.Tensor, targets: torch.Tensor):
+    def learn_local(self, queries: torch.Tensor, targets: torch.Tensor,
+                    record_ids=None):
         """Two-pathway learning with class-match check.
 
         1. Hit (sim >= vigilance, same class) → EMA update + key centroid drift
         2. Miss (below vigilance OR class collision) → allocate new slot via LFU
+
+        Args:
+            record_ids: Optional per-row external provenance IDs (any hashable),
+                a sequence of length ``B``. Captured into ``slot_records`` as the
+                actual write/merge history: a miss stamps the new slot with
+                ``{id}``, a same-class hit unions the id into the slot's set, and
+                a reused (evicted) slot's stale set is cleared first. Requires
+                ``track_provenance=True``; passing ids while provenance is off
+                raises ``ValueError`` so a caller never assumes capture happened.
         """
         now = time.time()
+        if record_ids is not None:
+            if not self.track_provenance:
+                raise ValueError(
+                    "record_ids provided but track_provenance=False — provenance "
+                    "was NOT captured. Construct ContinuousCAM(track_provenance="
+                    "True) to record write history.")
+            if len(record_ids) != queries.size(0):
+                raise ValueError(
+                    f"record_ids length {len(record_ids)} != batch size "
+                    f"{queries.size(0)}")
         queries = self._cast(queries)
         targets = self._cast(targets)
 
@@ -688,6 +758,20 @@ class ContinuousCAM(nn.Module):
             self.last_seen[hit_slots] = now
             self.usage[unique_slots] += 1
 
+            # Provenance: union each incoming record id into its destination
+            # slot's history set (a merge accumulates all sources that formed
+            # the prototype). `inverse` is aligned to the hit rows in order.
+            if self.slot_records is not None and record_ids is not None:
+                hit_rows = hits.nonzero(as_tuple=True)[0].tolist()
+                inv = inverse.tolist()
+                for k, local in enumerate(inv):
+                    slot = int(unique_slots[local].item())
+                    bucket = self.slot_records[slot]
+                    if bucket is None:
+                        bucket = set()
+                        self.slot_records[slot] = bucket
+                    bucket.add(record_ids[hit_rows[k]])
+
         # --- Batch allocation for misses ---
         if misses.any():
             miss_queries = queries[misses]
@@ -706,6 +790,20 @@ class ContinuousCAM(nn.Module):
             self.usage[new_slots] = 1
             self.hit_counts[new_slots] = 1
             self._update_key_norm(new_slots)
+
+            # Provenance: a fresh allocation owns a new history set. A reused
+            # (evicted) slot's stale set MUST be cleared first so the new
+            # prototype never inherits the previous occupant's sources. With no
+            # record_ids we still clear (don't invent ids).
+            if self.slot_records is not None:
+                alloc_slots = new_slots[:n_alloc].tolist()
+                if record_ids is not None:
+                    miss_rows = misses.nonzero(as_tuple=True)[0].tolist()
+                    for j, slot in enumerate(alloc_slots):
+                        self.slot_records[slot] = {record_ids[miss_rows[j]]}
+                else:
+                    for slot in alloc_slots:
+                        self.slot_records[slot] = None
 
         # Cold-start seed for the retrieval floor policy (issue #74). On the
         # very first batch, memory was empty when within_class_sims was computed

--- a/shutter_deck/persistence.py
+++ b/shutter_deck/persistence.py
@@ -28,6 +28,11 @@ VERSION = 3
 HEADER_FMT = "<4sHIIII"  # magic(4) + version(2) + max_entries(4) + key_dim(4) + value_dim(4) + n_occupied(4)
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
 
+# NOTE: ContinuousCAM.slot_records (per-slot provenance) is intentionally NOT
+# serialized here — it holds arbitrary Python hashables, not a fixed-width
+# tensor. A provenance sidecar (e.g. JSON) is a documented follow-up; loading a
+# state file leaves slot_records at its constructed default.
+#
 # Ordered list of (buffer_name, numpy_dtype) for serialization
 _TENSOR_FIELDS = [
     ("keys", np.float32),

--- a/shutter_deck/persistence.py
+++ b/shutter_deck/persistence.py
@@ -30,8 +30,9 @@ HEADER_SIZE = struct.calcsize(HEADER_FMT)
 
 # NOTE: ContinuousCAM.slot_records (per-slot provenance) is intentionally NOT
 # serialized here — it holds arbitrary Python hashables, not a fixed-width
-# tensor. A provenance sidecar (e.g. JSON) is a documented follow-up; loading a
-# state file leaves slot_records at its constructed default.
+# tensor. A provenance sidecar (e.g. JSON) is a documented follow-up. On load,
+# slot_records is explicitly reset to the cold default (see load_cam_state) so
+# stale provenance can never survive a load and mismatch the loaded tensors.
 #
 # Ordered list of (buffer_name, numpy_dtype) for serialization
 _TENSOR_FIELDS = [
@@ -118,6 +119,12 @@ def load_cam_state(cam, path: Path) -> bool:
                 return False
             arr = np.frombuffer(raw, dtype=dtype).reshape(buf.shape)
             buf.copy_(torch.from_numpy(arr.copy()))
+
+    # slot_records is not part of the binary format. Reset it to the cold
+    # default so stale in-memory provenance from prior use of this CAM cannot
+    # survive a load and mismatch the freshly loaded tensor state.
+    if getattr(cam, "track_provenance", False):
+        cam.slot_records = [None] * cam.max_entries
 
     logger.info("Loaded CAM state: %d occupied slots from %s", n_occupied, path)
     return True

--- a/tests/test_slot_records.py
+++ b/tests/test_slot_records.py
@@ -176,3 +176,33 @@ class TestAccessors:
         mapped = cam.records_for_slots(tr.final_slots)  # 2-D tensor flattens
         assert isinstance(mapped, list)
         assert all(isinstance(x, set) for x in mapped)
+
+    def test_negative_index_does_not_wrap_to_last_slot(self):
+        """trace.final_slots uses -1 padding; a negative index must map to an
+        empty set, NOT wrap to the last slot's provenance (PR #78 review, P1)."""
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True)
+        cam.slot_records[-1] = {"LAST"}  # poison the final slot
+        assert cam.records_for(-1) == set()
+        assert cam.records_for_slots(torch.tensor([-1, -1])) == [set(), set()]
+        # The real last slot is still reachable by its positive index.
+        assert cam.records_for(15) == {"LAST"}
+
+
+class TestPersistenceReset:
+    def test_load_clears_stale_provenance(self, tmp_path):
+        """Records aren't serialized; loading must reset slot_records so stale
+        in-memory provenance can't survive and mismatch loaded tensors."""
+        from shutter_deck.persistence import save_cam_state, load_cam_state
+
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.99)
+        cam.learn_local(torch.randn(2, 8), _one_hot([0, 1], 4),
+                        record_ids=["a", "b"])
+        assert any(r for r in cam.slot_records)  # precondition: has provenance
+
+        path = tmp_path / "state.bin"
+        save_cam_state(cam, path)
+        # Load back into the SAME (already-populated) cam → records must clear.
+        assert load_cam_state(cam, path) is True
+        assert cam.slot_records == [None] * 16

--- a/tests/test_slot_records.py
+++ b/tests/test_slot_records.py
@@ -1,0 +1,178 @@
+"""
+tests/test_slot_records.py — Per-slot provenance (the slot_records layer).
+
+Validates the fourth decoupling layer:
+    keys=geometry, values=payload, slot_labels=identity, slot_records=history.
+
+slot_records captures the ACTUAL write/merge history (which external record IDs
+formed each prototype) at learn time — never reconstructed from nearest-prototype
+assignment. It is opt-in (track_provenance=True); off by default so existing CAM
+behavior is byte-for-byte unchanged.
+"""
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from associative_core import ContinuousCAM
+
+
+def _one_hot(classes, n):
+    return F.one_hot(torch.as_tensor(classes), num_classes=n).float()
+
+
+class TestDisabledByDefault:
+    def test_off_by_default(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16)
+        assert cam.track_provenance is False
+        assert cam.slot_records is None
+
+    def test_record_ids_rejected_when_off(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16)
+        with pytest.raises(ValueError, match="track_provenance=False"):
+            cam.learn_local(torch.randn(2, 8), _one_hot([0, 1], 4),
+                            record_ids=["a", "b"])
+
+    def test_no_record_ids_unchanged_when_off(self):
+        """Default path must be untouched: no record_ids → no error, no records."""
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16)
+        cam.learn_local(torch.randn(3, 8), _one_hot([0, 1, 2], 4))
+        assert cam.slot_records is None
+
+    def test_accessors_raise_when_off(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16)
+        with pytest.raises(RuntimeError, match="track_provenance=False"):
+            cam.records_for(0)
+        with pytest.raises(RuntimeError, match="track_provenance=False"):
+            cam.records_for_slots([0, 1])
+
+
+class TestEnabled:
+    def test_init_allocates_empty_records(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True)
+        assert cam.slot_records == [None] * 16
+
+    def test_length_mismatch_raises(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True)
+        with pytest.raises(ValueError, match="!= batch size"):
+            cam.learn_local(torch.randn(3, 8), _one_hot([0, 1, 2], 4),
+                            record_ids=["only-one"])
+
+    def test_allocation_stamps_record(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.99)
+        cam.learn_local(torch.randn(3, 8), _one_hot([0, 1, 2], 4),
+                        record_ids=["x", "y", "z"])
+        occ = cam.occupied.nonzero(as_tuple=True)[0].tolist()
+        recorded = set().union(*(cam.records_for(s) for s in occ))
+        assert recorded == {"x", "y", "z"}
+        # Each fresh slot owns exactly one source id.
+        assert all(len(cam.records_for(s)) == 1 for s in occ)
+
+    def test_none_record_ids_does_not_invent(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.99)
+        cam.learn_local(torch.randn(2, 8), _one_hot([0, 1], 4))  # no ids
+        occ = cam.occupied.nonzero(as_tuple=True)[0].tolist()
+        assert all(cam.records_for(s) == set() for s in occ)
+
+
+class TestAccumulateOnMerge:
+    def test_same_slot_hit_unions(self):
+        """A same-class hit merges the new source id into the slot's set."""
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.0)  # all hits
+        key = F.normalize(torch.randn(1, 8), dim=-1)
+        cam.learn_local(key, _one_hot([1], 4), record_ids=["first"])
+        slot = cam.occupied.nonzero(as_tuple=True)[0].item()
+        assert cam.records_for(slot) == {"first"}
+
+        # Re-present the same key/class with a new source id → union, not replace.
+        cam.learn_local(key, _one_hot([1], 4), record_ids=["second"])
+        assert cam.records_for(slot) == {"first", "second"}
+
+    def test_batch_hits_to_one_slot_union(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.0)
+        key = F.normalize(torch.randn(1, 8), dim=-1)
+        cam.learn_local(key, _one_hot([2], 4), record_ids=["seed"])
+        slot = cam.occupied.nonzero(as_tuple=True)[0].item()
+        # A batch of 3 same-key rows all hit the one slot → all 3 ids union in.
+        batch = key.repeat(3, 1)
+        cam.learn_local(batch, _one_hot([2, 2, 2], 4),
+                        record_ids=["a", "b", "c"])
+        assert cam.records_for(slot) == {"seed", "a", "b", "c"}
+
+    def test_history_not_reconstructed_from_geometry(self):
+        """Guardrail: provenance reflects what was WRITTEN, even if a later
+        nearest-prototype assignment would attribute the source elsewhere."""
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.0)
+        ka = F.normalize(torch.tensor([[1.0, 0, 0, 0, 0, 0, 0, 0]]), dim=-1)
+        cam.learn_local(ka, _one_hot([0], 4), record_ids=["src-A"])
+        slot_a = cam.occupied.nonzero(as_tuple=True)[0].item()
+        # src-A lives on slot_a because that's where it was written.
+        assert "src-A" in cam.records_for(slot_a)
+
+
+class TestEvictionReuseClearsStale:
+    def test_reused_slot_drops_previous_sources(self):
+        # Capacity 2, pure LRU eviction, vigilance high so every write is a miss.
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=2,
+                            track_provenance=True, vigilance=0.999,
+                            adaptive_eviction=False, use_lfu=False)
+        keys = F.normalize(torch.randn(3, 8), dim=-1)
+        cam.learn_local(keys[0:1], _one_hot([0], 4), record_ids=["old0"])
+        cam.learn_local(keys[1:2], _one_hot([1], 4), record_ids=["old1"])
+        # Third miss must evict one slot and reuse it for "new2".
+        cam.learn_local(keys[2:3], _one_hot([2], 4), record_ids=["new2"])
+
+        all_ids = set().union(
+            *(cam.records_for(s) for s in range(cam.max_entries)))
+        assert "new2" in all_ids
+        # Exactly one of the originals was evicted; no slot carries a stale set
+        # alongside the new occupant.
+        for s in cam.occupied.nonzero(as_tuple=True)[0].tolist():
+            assert len(cam.records_for(s)) == 1
+
+    def test_reuse_without_record_ids_clears(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=2,
+                            track_provenance=True, vigilance=0.999,
+                            adaptive_eviction=False, use_lfu=False)
+        keys = F.normalize(torch.randn(3, 8), dim=-1)
+        cam.learn_local(keys[0:1], _one_hot([0], 4), record_ids=["old0"])
+        cam.learn_local(keys[1:2], _one_hot([1], 4), record_ids=["old1"])
+        # Reuse via eviction but WITHOUT new ids → reused slot must be cleared,
+        # not left holding the evicted occupant's id.
+        cam.learn_local(keys[2:3], _one_hot([2], 4))
+        records = [cam.records_for(s)
+                   for s in cam.occupied.nonzero(as_tuple=True)[0].tolist()]
+        # The surviving original keeps its id; the reused slot is empty.
+        assert set() in records
+
+
+class TestAccessors:
+    def test_records_for_slots_aligns_and_copies(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=16,
+                            track_provenance=True, vigilance=0.99)
+        cam.learn_local(torch.randn(2, 8), _one_hot([0, 1], 4),
+                        record_ids=["p", "q"])
+        occ = cam.occupied.nonzero(as_tuple=True)[0]
+        sets = cam.records_for_slots(occ)
+        assert len(sets) == occ.numel()
+        # Returned sets are copies: mutating them must not corrupt internal state.
+        sets[0].add("INTRUDER")
+        assert "INTRUDER" not in cam.records_for(int(occ[0].item()))
+
+    def test_records_for_slots_accepts_trace_tensor(self):
+        cam = ContinuousCAM(key_dim=8, value_dim=4, max_entries=64,
+                            track_provenance=True, vigilance=0.9)
+        labels = torch.randint(0, 4, (20,))
+        cam.learn_local(torch.randn(20, 8), _one_hot(labels, 4),
+                        record_ids=list(range(20)))
+        _, tr = cam.forward(torch.randn(5, 8), trace=True)
+        mapped = cam.records_for_slots(tr.final_slots)  # 2-D tensor flattens
+        assert isinstance(mapped, list)
+        assert all(isinstance(x, set) for x in mapped)


### PR DESCRIPTION
## Summary

Fourth and final layer of the **AgentAssociativeMemory** decoupling. Follows #77 (`slot_labels`).

| concern | owner |
|---|---|
| retrieval geometry | `keys` |
| continuous payload vectors | `values` |
| semantic identity | `slot_labels` |
| **provenance / write-merge history** | **`slot_records`** (new) |

`slot_records` captures the **actual write history** — which external record IDs were written into or merged into each prototype — *at learn time*. It is a first-class replacement for the lossy, after-the-fact reconstruction in `benchmarks/g42_cross_modal_corrected.py` (`compute_provenance` re-assigns every source embedding to its nearest prototype, O(N·P) and ≠ true history). **Provenance here is never reconstructed from geometry.**

## Design

- **Per-slot `list[set | None]`** of length `max_entries`. Records are arbitrary hashables (ints, `(cap_idx, img_id)` tuples, strings), so this is Python-side, **not a tensor buffer**. No premature `primary_record_id` tensor.
- **Opt-in** via `track_provenance=False` (default). Off → `slot_records is None`, core CAM math and every existing caller byte-for-byte unchanged. Passing `record_ids` while off raises `ValueError` so a caller never assumes capture happened.
- **`learn_local(queries, targets, record_ids=None)`**:
  - miss → new slot stamped `{id}`
  - same-class EMA hit → id **unions** into the slot's set (a merged prototype remembers *all* its sources)
  - batch hits to one slot → all ids union
  - reused (evicted) slot → stale set **cleared first**
  - no `record_ids` → never invents ids
- **Accessors** `records_for(slot)` / `records_for_slots(slots)` return read-only copies and accept a `RetrievalTrace`'s slot tensor, mapping retrieved prototypes back to sources without altering tensor retrieval.

## Not in scope (documented follow-ups)

- **Persistence**: `slot_records` holds arbitrary Python objects, so it is intentionally excluded from the binary format (note added in `persistence.py`). A JSON sidecar is the next step.
- Refactoring `g42` to consume native provenance instead of reconstructing it.

## Tests

`tests/test_slot_records.py` (15): opt-in gating + `ValueError`/`RuntimeError` guards, allocation stamping, accumulate-on-merge (single + batch), eviction-reuse clears stale (with/without ids), history-not-reconstructed guardrail, accessor copy/alignment. Full suite: **394 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)