### PR TITLE
Provenance JSON sidecar + g42 native slot_records refactor

### DIFF
--- a/benchmarks/g42_cross_modal_corrected.py
+++ b/benchmarks/g42_cross_modal_corrected.py
@@ -194,6 +194,7 @@ def build_fam(N_img: int, max_entries: int) -> FastAssociativeMemory:
         adaptive_eviction=True,
         adapter=None,
         nstp=None,
+        track_provenance=True,
     ).to(DEVICE)
 
 
@@ -204,12 +205,19 @@ def write_fam_interleaved(fam, img_embs, cap_embs, cap_imgid, N_img):
         caps_for_img[img_id].append(ci)
 
     seq_feats, seq_labels = [], []
+    # Per-position provenance record ids, modality-tagged so the true write
+    # history can be partitioned back into image vs caption origins:
+    #   ("img", image_id)        — an image write
+    #   ("cap", cap_idx, image_id) — a caption write
+    seq_records: list[tuple] = []
     for img_id in range(N_img):
         seq_feats.append(img_embs[img_id])
         seq_labels.append(img_id)
+        seq_records.append(("img", img_id))
         for ci in caps_for_img[img_id]:
             seq_feats.append(cap_embs[ci])
             seq_labels.append(img_id)
+            seq_records.append(("cap", ci, img_id))
 
     seq_feats = torch.stack(seq_feats, dim=0)
     seq_labels = torch.tensor(seq_labels, dtype=torch.long)
@@ -220,7 +228,10 @@ def write_fam_interleaved(fam, img_embs, cap_embs, cap_imgid, N_img):
     for i in range(0, len(seq_feats), batch):
         bx = seq_feats[i:i + batch].to(DEVICE)
         bt = targets[i:i + batch].to(DEVICE)
-        fam.core_cam.learn_local(fam._project(bx), bt)
+        # Pass record_ids so slot_records captures the actual write/merge
+        # history; provenance is then read natively, not reconstructed.
+        fam.core_cam.learn_local(fam._project(bx), bt,
+                                 record_ids=seq_records[i:i + batch])
         if i % 2000 == 0:
             n_occ = int(fam.core_cam.occupied.sum().item())
             print(f"    write {i}/{len(seq_feats)} | prototypes: {n_occ}", end="\r")
@@ -235,26 +246,31 @@ def write_fam_interleaved(fam, img_embs, cap_embs, cap_imgid, N_img):
 # ---------------------------------------------------------------------------
 
 @torch.no_grad()
-def compute_provenance(fam, img_embs, cap_embs, cap_imgid, N_img):
+def compute_provenance(fam):
+    """Read each prototype's TRUE write/merge history from native slot_records.
+
+    This replaces the former O(N*P) reconstruction that re-assigned every image
+    and caption to its current nearest prototype (argmax cosine). That answered
+    "where would this item retrieve to now"; slot_records answers "which writes
+    actually formed this prototype" — the question the cross-modal merge metric
+    intends. The two differ: a coincidental nearest-neighbour is not a merge,
+    and an evicted item's record is dropped rather than reattributed.
+
+    Records were written modality-tagged in write_fam_interleaved:
+      ("img", image_id)          -> proto_img_ids[slot]
+      ("cap", cap_idx, image_id) -> proto_cap_ids[slot]
+    """
     valid_idx = fam.core_cam.occupied.nonzero(as_tuple=True)[0]
-    proto_keys = fam.core_cam._keys_norm[valid_idx]
-
-    def assign(feats):
-        assigns = []
-        for i in range(0, len(feats), 512):
-            sims = feats[i:i + 512].float().to(DEVICE) @ proto_keys.T
-            assigns.append(valid_idx[sims.argmax(dim=1)].cpu())
-        return torch.cat(assigns, dim=0)
-
-    img_assign = assign(img_embs)
-    cap_assign = assign(cap_embs)
 
     proto_img_ids: dict[int, set] = defaultdict(set)
     proto_cap_ids: dict[int, set] = defaultdict(set)
-    for img_id in range(N_img):
-        proto_img_ids[img_assign[img_id].item()].add(img_id)
-    for ci, img_id in enumerate(cap_imgid.tolist()):
-        proto_cap_ids[cap_assign[ci].item()].add((ci, img_id))
+    for slot in valid_idx.tolist():
+        for rec in fam.core_cam.records_for(slot):
+            kind = rec[0]
+            if kind == "img":
+                proto_img_ids[slot].add(rec[1])           # image_id
+            elif kind == "cap":
+                proto_cap_ids[slot].add((rec[1], rec[2]))  # (cap_idx, image_id)
 
     return {
         "proto_img_ids": dict(proto_img_ids),
@@ -537,7 +553,7 @@ def main():
 
     # Provenance + diagnostics
     print("  Computing provenance ...")
-    prov = compute_provenance(fam, img_embs, cap_embs, cap_imgid, N_img)
+    prov = compute_provenance(fam)
     diag = compute_diagnostics(fam, prov, N_img, n_written)
 
     # Primary kill signal: cross-modal merge rate

--- a/fast_associative_memory.py
+++ b/fast_associative_memory.py
@@ -79,7 +79,8 @@ class FastAssociativeMemory(nn.Module):
                  adaptive_eviction: bool = True,
                  adapter: MetricAdapter | None = None,
                  nstp: NSTPController | None = None,
-                  dynamic_vigilance=None):
+                  dynamic_vigilance=None,
+                 track_provenance: bool = False):
         super().__init__()
         self.input_dim = input_dim
         self.value_dim = value_dim
@@ -117,6 +118,7 @@ class FastAssociativeMemory(nn.Module):
             use_bfloat16=use_bfloat16,
             immutable_keys=immutable_keys,
             dynamic_vigilance=dynamic_vigilance,
+            track_provenance=track_provenance,
         )
         if nstp is not None:
             self.core_cam.nstp = nstp

--- a/fast_associative_memory.py
+++ b/fast_associative_memory.py
@@ -79,7 +79,7 @@ class FastAssociativeMemory(nn.Module):
                  adaptive_eviction: bool = True,
                  adapter: MetricAdapter | None = None,
                  nstp: NSTPController | None = None,
-                  dynamic_vigilance=None,
+                 dynamic_vigilance=None,
                  track_provenance: bool = False):
         super().__init__()
         self.input_dim = input_dim

--- a/shutter_deck/persistence.py
+++ b/shutter_deck/persistence.py
@@ -222,7 +222,9 @@ def _decode_record(obj):
 def save_provenance_sidecar(cam, state_path: Path) -> bool:
     """Write ``cam.slot_records`` to a JSON sidecar next to ``state_path``.
 
-    No-op (returns False) when provenance tracking is disabled. The sidecar
+    No-op (returns False) when provenance tracking is disabled or when the
+    binary state file does not yet exist — a sidecar is only meaningful bound to
+    real on-disk bytes, so it is never written with a null digest. The sidecar
     stores a SHA-256 digest of the binary state file so a later load can refuse
     to apply provenance onto a state file it was not saved alongside. Written
     via tmp-file + atomic rename, mirroring the binary writer.
@@ -231,8 +233,15 @@ def save_provenance_sidecar(cam, state_path: Path) -> bool:
         return False
 
     state_path = Path(state_path)
+    if not state_path.exists():
+        # A sidecar is only meaningful bound to a binary state file. Refuse to
+        # write one with a null digest that nothing could later validate against.
+        logger.warning(
+            "No binary state file at %s — refusing to write an unbound provenance sidecar.",
+            state_path)
+        return False
     sidecar = _provenance_path(state_path)
-    digest = _file_digest(state_path) if state_path.exists() else None
+    digest = _file_digest(state_path)
 
     records = {
         str(slot): [_encode_record(r) for r in rec]
@@ -267,6 +276,12 @@ def load_provenance_sidecar(cam, state_path: Path) -> bool:
         return False
 
     state_path = Path(state_path)
+    if not state_path.exists():
+        # No tensor state to bind to — a provenance set with no matching binary
+        # cannot be validated, so never apply one.
+        logger.warning(
+            "No binary state file at %s — provenance stays cold.", state_path)
+        return False
     sidecar = _provenance_path(state_path)
     if not sidecar.exists():
         logger.info("No provenance sidecar at %s — provenance stays cold.", sidecar)
@@ -277,6 +292,11 @@ def load_provenance_sidecar(cam, state_path: Path) -> bool:
             payload = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Unreadable provenance sidecar %s (%s) — provenance stays cold.", sidecar, e)
+        return False
+
+    if not isinstance(payload, dict):
+        logger.warning(
+            "Provenance sidecar %s is not a JSON object — provenance stays cold.", sidecar)
         return False
 
     if payload.get("provenance_version") != PROVENANCE_VERSION:
@@ -291,13 +311,17 @@ def load_provenance_sidecar(cam, state_path: Path) -> bool:
         return False
 
     expected = payload.get("state_digest")
-    actual = _file_digest(state_path) if state_path.exists() else None
+    actual = _file_digest(state_path)  # state_path existence checked above
     if expected != actual:
         logger.warning(
             "Provenance sidecar digest mismatch for %s — provenance stays cold.", state_path)
         return False
 
     records = payload.get("records", {})
+    if not isinstance(records, dict):
+        logger.warning(
+            "Provenance sidecar %s has malformed 'records' — provenance stays cold.", sidecar)
+        return False
     restored = [None] * cam.max_entries
     try:
         for slot_str, rec_list in records.items():

--- a/shutter_deck/persistence.py
+++ b/shutter_deck/persistence.py
@@ -11,6 +11,8 @@ Layout:
   --- tensor blobs (contiguous float32 / float64 / bool as appropriate) ---
 """
 
+import hashlib
+import json
 import logging
 import struct
 from pathlib import Path
@@ -29,10 +31,13 @@ HEADER_FMT = "<4sHIIII"  # magic(4) + version(2) + max_entries(4) + key_dim(4) +
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
 
 # NOTE: ContinuousCAM.slot_records (per-slot provenance) is intentionally NOT
-# serialized here — it holds arbitrary Python hashables, not a fixed-width
-# tensor. A provenance sidecar (e.g. JSON) is a documented follow-up. On load,
-# slot_records is explicitly reset to the cold default (see load_cam_state) so
-# stale provenance can never survive a load and mismatch the loaded tensors.
+# part of the binary format above — it holds arbitrary Python hashables, not a
+# fixed-width tensor. It is persisted *separately* in an opt-in JSON sidecar
+# (see save_provenance_sidecar / load_provenance_sidecar and the write_provenance
+# / read_provenance flags). On a binary load, slot_records is still reset to the
+# cold default first, so stale provenance can never survive a load and mismatch
+# the loaded tensors; the sidecar is only re-applied when explicitly requested
+# AND its bound digest matches the binary file it was saved alongside.
 #
 # Ordered list of (buffer_name, numpy_dtype) for serialization
 _TENSOR_FIELDS = [
@@ -52,8 +57,14 @@ def _tensor_byte_size(cam, name: str, dtype) -> int:
     return int(np.prod(buf.shape)) * np.dtype(dtype).itemsize
 
 
-def save_cam_state(cam, path: Path) -> None:
-    """Serialize full CAM state to a binary file with atomic rename."""
+def save_cam_state(cam, path: Path, write_provenance: bool = False) -> None:
+    """Serialize full CAM state to a binary file with atomic rename.
+
+    When ``write_provenance`` is True and the CAM tracks provenance, a JSON
+    sidecar (``<path>.prov.json``) is written *after* the binary file so its
+    bound digest covers the final on-disk bytes. Defaults to False, leaving the
+    binary format and existing callers byte-for-byte unchanged.
+    """
     path = Path(path)
     tmp_path = path.with_suffix(".tmp")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -77,9 +88,19 @@ def save_cam_state(cam, path: Path) -> None:
     tmp_path.rename(path)
     logger.info("Saved CAM state: %d occupied slots → %s", n_occupied, path)
 
+    if write_provenance:
+        save_provenance_sidecar(cam, path)
 
-def load_cam_state(cam, path: Path) -> bool:
-    """Load CAM state from a binary file. Returns True on success, False on mismatch/missing."""
+
+def load_cam_state(cam, path: Path, read_provenance: bool = False) -> bool:
+    """Load CAM state from a binary file. Returns True on success, False on mismatch/missing.
+
+    When ``read_provenance`` is True and the CAM tracks provenance, the JSON
+    sidecar is re-applied *after* the cold reset of ``slot_records`` — but only
+    if its bound digest matches this binary file (otherwise slot_records is left
+    at the cold default). Defaults to False, preserving the existing contract
+    that a load always clears stale provenance.
+    """
     path = Path(path)
     if not path.exists():
         logger.info("No state file at %s — starting cold.", path)
@@ -125,6 +146,170 @@ def load_cam_state(cam, path: Path) -> bool:
     # survive a load and mismatch the freshly loaded tensor state.
     if getattr(cam, "track_provenance", False):
         cam.slot_records = [None] * cam.max_entries
+        if read_provenance:
+            load_provenance_sidecar(cam, path)
 
     logger.info("Loaded CAM state: %d occupied slots from %s", n_occupied, path)
+    return True
+
+
+# ----------------------------------------------------------------------------
+# Provenance sidecar (slot_records) — JSON, kept out of the binary format.
+# ----------------------------------------------------------------------------
+PROVENANCE_SUFFIX = ".prov.json"
+PROVENANCE_VERSION = 1
+
+
+def _provenance_path(state_path: Path) -> Path:
+    """Sidecar path for a binary state file: ``<state_path>.prov.json``.
+
+    Appends rather than replacing the suffix so a ``foo.bin`` state and its
+    ``foo.bin.prov.json`` sidecar stay unambiguously paired.
+    """
+    return Path(str(Path(state_path)) + PROVENANCE_SUFFIX)
+
+
+def _file_digest(path: Path) -> str:
+    """SHA-256 hex digest of a file's bytes (binds a sidecar to its state file)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _encode_record(r):
+    """Encode one hashable provenance record into a type-tagged JSON value.
+
+    JSON collapses int/str/tuple distinctions that ``slot_records`` relies on
+    (a tuple key is not its list form; ``5`` is not ``"5"``). Tagging the type
+    preserves an exact round-trip. ``bool`` is checked before ``int`` because
+    ``bool`` is an ``int`` subclass.
+    """
+    if isinstance(r, bool):
+        return {"t": "bool", "v": r}
+    if isinstance(r, int):
+        return {"t": "int", "v": r}
+    if isinstance(r, float):
+        return {"t": "float", "v": r}
+    if isinstance(r, str):
+        return {"t": "str", "v": r}
+    if isinstance(r, tuple):
+        return {"t": "tuple", "v": [_encode_record(x) for x in r]}
+    raise TypeError(
+        f"Unsupported provenance record type {type(r).__name__!r}: {r!r}. "
+        "slot_records must hold int/float/str/bool or (nested) tuples thereof."
+    )
+
+
+def _decode_record(obj):
+    """Inverse of :func:`_encode_record`."""
+    t = obj["t"]
+    v = obj["v"]
+    if t == "bool":
+        return bool(v)
+    if t == "int":
+        return int(v)
+    if t == "float":
+        return float(v)
+    if t == "str":
+        return str(v)
+    if t == "tuple":
+        return tuple(_decode_record(x) for x in v)
+    raise ValueError(f"Unknown provenance record tag {t!r}")
+
+
+def save_provenance_sidecar(cam, state_path: Path) -> bool:
+    """Write ``cam.slot_records`` to a JSON sidecar next to ``state_path``.
+
+    No-op (returns False) when provenance tracking is disabled. The sidecar
+    stores a SHA-256 digest of the binary state file so a later load can refuse
+    to apply provenance onto a state file it was not saved alongside. Written
+    via tmp-file + atomic rename, mirroring the binary writer.
+    """
+    if not getattr(cam, "track_provenance", False) or cam.slot_records is None:
+        return False
+
+    state_path = Path(state_path)
+    sidecar = _provenance_path(state_path)
+    digest = _file_digest(state_path) if state_path.exists() else None
+
+    records = {
+        str(slot): [_encode_record(r) for r in rec]
+        for slot, rec in enumerate(cam.slot_records)
+        if rec  # skip None and empty sets
+    }
+    payload = {
+        "provenance_version": PROVENANCE_VERSION,
+        "max_entries": cam.max_entries,
+        "state_digest": digest,
+        "records": records,
+    }
+
+    tmp = sidecar.with_suffix(sidecar.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    tmp.rename(sidecar)
+    logger.info("Saved provenance sidecar: %d slots → %s", len(records), sidecar)
+    return True
+
+
+def load_provenance_sidecar(cam, state_path: Path) -> bool:
+    """Restore ``cam.slot_records`` from the JSON sidecar for ``state_path``.
+
+    Returns True only when the sidecar exists, parses, and is consistent with
+    the CAM (version + ``max_entries``) and the binary state file (digest). On
+    any mismatch or error it logs a warning, leaves ``slot_records`` untouched
+    (the caller's cold default), and returns False — the same graceful-fallback
+    contract as :func:`load_cam_state`.
+    """
+    if not getattr(cam, "track_provenance", False):
+        return False
+
+    state_path = Path(state_path)
+    sidecar = _provenance_path(state_path)
+    if not sidecar.exists():
+        logger.info("No provenance sidecar at %s — provenance stays cold.", sidecar)
+        return False
+
+    try:
+        with open(sidecar, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Unreadable provenance sidecar %s (%s) — provenance stays cold.", sidecar, e)
+        return False
+
+    if payload.get("provenance_version") != PROVENANCE_VERSION:
+        logger.warning(
+            "Provenance sidecar version mismatch (file=%r, code=%d) — provenance stays cold.",
+            payload.get("provenance_version"), PROVENANCE_VERSION)
+        return False
+    if payload.get("max_entries") != cam.max_entries:
+        logger.warning(
+            "Provenance sidecar max_entries mismatch (file=%r, cam=%d) — provenance stays cold.",
+            payload.get("max_entries"), cam.max_entries)
+        return False
+
+    expected = payload.get("state_digest")
+    actual = _file_digest(state_path) if state_path.exists() else None
+    if expected != actual:
+        logger.warning(
+            "Provenance sidecar digest mismatch for %s — provenance stays cold.", state_path)
+        return False
+
+    records = payload.get("records", {})
+    restored = [None] * cam.max_entries
+    try:
+        for slot_str, rec_list in records.items():
+            slot = int(slot_str)
+            if not (0 <= slot < cam.max_entries):
+                logger.warning("Provenance slot %d out of range — provenance stays cold.", slot)
+                return False
+            restored[slot] = {_decode_record(x) for x in rec_list}
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning("Corrupt provenance record in %s (%s) — provenance stays cold.", sidecar, e)
+        return False
+
+    cam.slot_records = restored
+    logger.info("Loaded provenance sidecar: %d slots from %s", len(records), sidecar)
     return True

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -15,7 +15,10 @@ import torch
 import pytest
 
 from associative_core import ContinuousCAM
-from shutter_deck.persistence import save_cam_state, load_cam_state, HEADER_FMT, MAGIC, VERSION
+from shutter_deck.persistence import (
+    save_cam_state, load_cam_state, HEADER_FMT, MAGIC, VERSION,
+    save_provenance_sidecar, load_provenance_sidecar, _provenance_path,
+)
 
 
 @pytest.fixture
@@ -123,3 +126,99 @@ class TestAtomicWrite:
         tmp_path = state_path.with_suffix(".tmp")
         assert not tmp_path.exists()
         assert state_path.exists()
+
+
+@pytest.fixture
+def prov_cam():
+    """A provenance-tracking CAM with mixed-type record sets on a few slots."""
+    c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                      track_provenance=True)
+    for i in range(5):
+        c.keys[i] = torch.randn(32)
+        c.values[i] = torch.randn(8)
+        c.occupied[i] = True
+        c.slot_labels[i] = i % 8
+    c._keys_norm[:5] = torch.nn.functional.normalize(c.keys[:5], dim=-1)
+    # Heterogeneous hashables: int, str, float, bool, and a (nested) tuple.
+    c.slot_records[0] = {1, 2, 3}
+    c.slot_records[1] = {"alpha", "beta"}
+    c.slot_records[2] = {("img", 7), ("cap", ("nested", 9))}
+    c.slot_records[3] = {3.5, True, "mixed", 42}
+    # slot 4 occupied but left with no provenance (None) — must stay None.
+    return c
+
+
+class TestProvenanceSidecar:
+    def test_roundtrip_preserves_records_and_types(self, prov_cam, state_path):
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        assert _provenance_path(state_path).exists()
+
+        cam2 = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                             track_provenance=True)
+        assert load_cam_state(cam2, state_path, read_provenance=True) is True
+        assert cam2.slot_records == prov_cam.slot_records
+        # Type fidelity: tuple stayed a tuple, int 42 did not become "42".
+        assert ("img", 7) in cam2.slot_records[2]
+        assert 42 in cam2.slot_records[3] and "42" not in cam2.slot_records[3]
+
+    def test_unoccupied_slot_stays_none(self, prov_cam, state_path):
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        cam2 = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                             track_provenance=True)
+        load_cam_state(cam2, state_path, read_provenance=True)
+        assert cam2.slot_records[4] is None
+        assert cam2.slot_records[50] is None
+
+    def test_no_sidecar_written_without_flag(self, prov_cam, state_path):
+        save_cam_state(prov_cam, state_path)  # write_provenance defaults False
+        assert not _provenance_path(state_path).exists()
+
+    def test_load_without_flag_leaves_cold_default(self, prov_cam, state_path):
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        cam2 = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                             track_provenance=True)
+        load_cam_state(cam2, state_path)  # read_provenance defaults False
+        assert cam2.slot_records == [None] * 100
+
+    def test_missing_sidecar_graceful(self, cam, state_path):
+        # Binary saved without a sidecar; explicit sidecar load returns False.
+        save_cam_state(cam, state_path)
+        c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                          track_provenance=True)
+        assert load_provenance_sidecar(c, state_path) is False
+        assert c.slot_records == [None] * 100
+
+    def test_digest_mismatch_rejected(self, prov_cam, state_path):
+        """A sidecar paired to a different binary file must not be applied."""
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        # Re-save the binary (new random-free content is identical here, so
+        # mutate a buffer to force a different digest) without refreshing sidecar.
+        prov_cam.keys[0] += 1.0
+        save_cam_state(prov_cam, state_path)  # binary only — sidecar now stale
+        cam2 = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                             track_provenance=True)
+        load_cam_state(cam2, state_path, read_provenance=True)
+        assert cam2.slot_records == [None] * 100
+
+    def test_corrupt_sidecar_graceful(self, prov_cam, state_path):
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        _provenance_path(state_path).write_text("{ not valid json")
+        cam2 = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                             track_provenance=True)
+        assert load_cam_state(cam2, state_path, read_provenance=True) is True
+        assert cam2.slot_records == [None] * 100  # binary ok, provenance cold
+
+    def test_max_entries_mismatch_rejected(self, prov_cam, tmp_path):
+        sp = tmp_path / "state.bin"
+        save_cam_state(prov_cam, sp, write_provenance=True)
+        # A CAM of different size can't even pass the binary load; test the
+        # sidecar guard directly by hand-loading against a mismatched CAM.
+        c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=200,
+                          track_provenance=True)
+        assert load_provenance_sidecar(c, sp) is False
+        assert c.slot_records == [None] * 200
+
+    def test_save_noop_when_provenance_disabled(self, cam, state_path):
+        save_cam_state(cam, state_path)  # cam has track_provenance=False
+        assert save_provenance_sidecar(cam, state_path) is False
+        assert not _provenance_path(state_path).exists()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -222,3 +222,43 @@ class TestProvenanceSidecar:
         save_cam_state(cam, state_path)  # cam has track_provenance=False
         assert save_provenance_sidecar(cam, state_path) is False
         assert not _provenance_path(state_path).exists()
+
+    def test_save_refuses_unbound_sidecar(self, prov_cam, state_path):
+        """No binary state file → no sidecar (would be unbound / null digest)."""
+        assert not state_path.exists()
+        assert save_provenance_sidecar(prov_cam, state_path) is False
+        assert not _provenance_path(state_path).exists()
+
+    def test_load_rejects_missing_state_file(self, prov_cam, state_path):
+        """A sidecar with no matching binary state file must not be applied."""
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        state_path.unlink()  # remove the binary, leave the sidecar in place
+        assert _provenance_path(state_path).exists()
+        c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                          track_provenance=True)
+        assert load_provenance_sidecar(c, state_path) is False
+        assert c.slot_records == [None] * 100
+
+    @pytest.mark.parametrize("bad", ["[]", '{"records": []}', '"a string"', "42"])
+    def test_load_rejects_wrong_shape_json(self, prov_cam, state_path, bad):
+        """Valid JSON of the wrong shape → graceful cold fallback, not a crash."""
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        _provenance_path(state_path).write_text(bad)
+        c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                          track_provenance=True)
+        # Must return False (or the digest guard fires first) — never raise.
+        assert load_provenance_sidecar(c, state_path) is False
+        assert c.slot_records == [None] * 100
+
+    def test_load_rejects_malformed_records_field(self, prov_cam, state_path):
+        """Valid version/digest but non-dict 'records' → graceful, not a crash."""
+        import json
+        save_cam_state(prov_cam, state_path, write_provenance=True)
+        sidecar = _provenance_path(state_path)
+        payload = json.loads(sidecar.read_text())
+        payload["records"] = []  # wrong shape; version/max_entries/digest intact
+        sidecar.write_text(json.dumps(payload))
+        c = ContinuousCAM(key_dim=32, value_dim=8, max_entries=100,
+                          track_provenance=True)
+        assert load_provenance_sidecar(c, state_path) is False
+        assert c.slot_records == [None] * 100


### PR DESCRIPTION
Two documented follow-ups to the `slot_records` layer (PR #78).

## 1. Provenance persistence sidecar (`shutter_deck/persistence.py`)

`slot_records` is deliberately out of the binary format (arbitrary Python hashables, not fixed-width tensors). This adds an opt-in JSON sidecar that persists it separately:

- `save_provenance_sidecar` / `load_provenance_sidecar` serialize `slot_records` to `<state>.bin.prov.json`, plus `write_provenance` / `read_provenance` flags on `save_cam_state` / `load_cam_state`.
- **Defaults are `False`** — binary format and the deliberate cold-reset of `slot_records` on load stay byte-for-byte unchanged.
- A **SHA-256 digest** of the binary file is stored in the sidecar; on load, a digest / version / `max_entries` mismatch (or any parse error) falls back to the cold default and returns `False`, preserving the invariant that provenance never survives onto mismatched tensors.
- **Type-tagged encoding** round-trips `int`/`float`/`str`/`bool` and (nested) tuples exactly (a tuple stays a tuple; `42 != "42"`).
- 11 new tests.

## 2. `g42_cross_modal_corrected` refactor

- `compute_provenance` now reads the **true write/merge history** from native `slot_records` instead of the O(N·P) nearest-prototype reconstruction. Writes pass modality-tagged `record_ids`.
- `cross_modal_merge_rate` / modality breakdown now reflect *actual* merges (a real cross-modal vigilance hit), not coincidental nearest-neighbour assignment. **Reported numbers shift to the truer measurement.**
- Threaded `track_provenance` through `FastAssociativeMemory` (opt-in, default `False`). `g42_cross_modal_retrieval` left unchanged (deliberate scope).

## Testing

- `tests/test_persistence.py` + `tests/test_slot_records.py`: 36 passed
- FAM-related sweep: 77 passed
- All changed files byte-compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)