### PR TITLE
Add VisionDriftStream selection-state snapshot (A2b scaffolding)

### DIFF
--- a/benchmarks/probe_contraction.py
+++ b/benchmarks/probe_contraction.py
@@ -51,6 +51,7 @@ import csv
 import math
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import torch
@@ -253,6 +254,24 @@ def _resolve_vision_cache(path: str | None) -> Path:
         "--vision-cache)")
 
 
+@dataclass(frozen=True)
+class VisionSelectionState:
+    """Frozen, read-only snapshot of a ``VisionDriftStream``'s selection state.
+
+    Every field is a fresh clone of the stream's internal tensors, so a caller
+    (e.g. the A2b ``ReembedDriftStream``, which must replay the *same* cache rows
+    back to source images) can consume the exact selection without recomputing
+    RNG / class selection / assignment, and without being able to mutate the
+    stream. Indices are cache rows (into the on-disk cache's ``embeds``/``labels``)
+    in the same order as ``train_X`` / ``held_X`` / ``attractor_feats``.
+    """
+    train_indices: torch.Tensor       # (n_train,) cache rows behind train_X
+    held_indices: torch.Tensor        # (n_held,)  cache rows behind held_X
+    attractor_indices: torch.Tensor   # (A,)       cache rows behind attractor_feats
+    train_assign: torch.Tensor        # (n_train,) per-train-sample -> attractor pool index
+    held_assign: torch.Tensor         # (n_held,)  per-held-sample  -> attractor pool index
+
+
 class VisionDriftStream:
     """Epoch-ordered DINOv2 ViT-L/14 feature stream whose inter-class similarity rises.
 
@@ -296,6 +315,7 @@ class VisionDriftStream:
 
         need = samples_per_class + held_out_per_class
         train_blocks, held_blocks = [], []
+        train_idx_blocks, held_idx_blocks = [], []
         self.train_labels: list[int] = []
         self.held_labels: list[int] = []
         for ci, cat in enumerate(categories):
@@ -307,6 +327,8 @@ class VisionDriftStream:
             tr, ho = perm[:samples_per_class], perm[samples_per_class:need]
             train_blocks.append(embeds[tr])
             held_blocks.append(embeds[ho])
+            train_idx_blocks.append(tr)
+            held_idx_blocks.append(ho)
             self.train_labels += [ci] * samples_per_class
             self.held_labels += [ci] * held_out_per_class
 
@@ -316,6 +338,12 @@ class VisionDriftStream:
         aidx = aidx[torch.randperm(aidx.numel(), generator=rng)]
         self.attractor_feats = embeds[aidx]                # (A, D), unit
         self.attractor_category = attractor_category
+        # Cache-row indices behind each selected pool (into the on-disk cache's
+        # `embeds`/`labels`), in the SAME order as train_X / held_X / attractor_feats.
+        # Stored only for read-only export via `selection_state`; not used in blend.
+        self._train_indices = torch.cat(train_idx_blocks, dim=0)   # (n_train,)
+        self._held_indices = torch.cat(held_idx_blocks, dim=0)     # (n_held,)
+        self._attractor_indices = aidx                             # (A,)
 
         self.train_X = torch.cat(train_blocks, dim=0)      # (n_train, D)
         self.held_X = torch.cat(held_blocks, dim=0)        # (n_held, D)
@@ -342,6 +370,24 @@ class VisionDriftStream:
         held_q = self._blend(self.held_X, self._held_assign, contraction)
         train_y = F.one_hot(self.train_lab, num_classes=self.num_classes).float()
         return (train_q, train_y, self.train_lab), (held_q, self.held_lab)
+
+    @property
+    def selection_state(self) -> "VisionSelectionState":
+        """Read-only snapshot of which cache rows this stream selected.
+
+        Returns a frozen ``VisionSelectionState`` of **cloned** tensors, so a
+        consumer can replay the identical selection (the A2b paired-path arm)
+        without recomputing RNG/selection/assignment and without being able to
+        mutate this stream's internal state. Purely an accessor over state fixed
+        at construction — it does not change any selection or blend behavior.
+        """
+        return VisionSelectionState(
+            train_indices=self._train_indices.clone(),
+            held_indices=self._held_indices.clone(),
+            attractor_indices=self._attractor_indices.clone(),
+            train_assign=self._train_assign.clone(),
+            held_assign=self._held_assign.clone(),
+        )
 
 
 def main() -> None:

--- a/tests/test_vision_selection_state.py
+++ b/tests/test_vision_selection_state.py
@@ -1,0 +1,116 @@
+"""Read-only selection-state exposure on `VisionDriftStream` (A2b scaffolding).
+
+The A2b paired-path arm (`ReembedDriftStream`, not built yet) must replay the
+*exact same* cache rows `VisionDriftStream` selected — same train/held/attractor
+rows and the same per-sample attractor assignment — without recomputing RNG,
+class selection, or assignment. This pins the only thing that exposure must
+guarantee: `selection_state` reports the internally selected rows, is stable
+across calls, and hands back clones so a consumer cannot mutate the stream.
+
+Uses a tiny synthetic `.pt` cache (this is selection-state plumbing, not
+ImageNet-R endpoint recovery), so it runs without the host-only feature cache.
+"""
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "benchmarks"))
+
+from probe_contraction import VisionDriftStream, VisionSelectionState  # noqa: E402
+
+CATEGORIES = [0, 1, 2]
+ATTRACTOR = 9
+SAMPLES_PER_CLASS = 4
+HELD_PER_CLASS = 3
+SEED = 1234
+D = 8
+PER_CLASS_CACHE = 10  # > samples+held; gives selection something to choose among
+
+
+def _write_synthetic_cache(path: Path) -> torch.Tensor:
+    """Write a {'embeds','labels'} cache with deterministic, per-row-unique rows.
+
+    Row r gets feature value r+1 broadcast across D, so `embeds[i]` is uniquely
+    identifiable — letting the test prove indices point at the selected rows.
+    Returns the raw (un-normalized) embeds for independent verification.
+    """
+    classes = CATEGORIES + [ATTRACTOR]
+    n = len(classes) * PER_CLASS_CACHE
+    embeds = torch.empty(n, D)
+    labels = torch.empty(n, dtype=torch.long)
+    for r in range(n):
+        embeds[r] = float(r + 1)
+    for ci, cat in enumerate(classes):
+        labels[ci * PER_CLASS_CACHE:(ci + 1) * PER_CLASS_CACHE] = cat
+    torch.save({"embeds": embeds, "labels": labels}, path)
+    return embeds
+
+
+def _build_stream(tmp_path: Path) -> tuple[VisionDriftStream, torch.Tensor]:
+    cache = tmp_path / "synthetic_cache.pt"
+    raw_embeds = _write_synthetic_cache(cache)
+    stream = VisionDriftStream(
+        categories=CATEGORIES, attractor_category=ATTRACTOR,
+        samples_per_class=SAMPLES_PER_CLASS, held_out_per_class=HELD_PER_CLASS,
+        seed=SEED, cache_path=str(cache))
+    return stream, raw_embeds
+
+
+def test_selection_state_exposure(tmp_path):
+    stream, raw_embeds = _build_stream(tmp_path)
+    norm_embeds = F.normalize(raw_embeds, dim=-1)
+    st = stream.selection_state
+
+    assert isinstance(st, VisionSelectionState)
+
+    # 1. Exposed indices equal the internally selected indices.
+    assert torch.equal(st.train_indices, stream._train_indices)
+    assert torch.equal(st.held_indices, stream._held_indices)
+    assert torch.equal(st.attractor_indices, stream._attractor_indices)
+    assert torch.equal(st.train_assign, stream._train_assign)
+    assert torch.equal(st.held_assign, stream._held_assign)
+
+    # ...and those indices genuinely address the selected feature rows, in the
+    # same order as the blended pools (the property's whole reason to exist).
+    assert torch.equal(norm_embeds[st.train_indices], stream.train_X)
+    assert torch.equal(norm_embeds[st.held_indices], stream.held_X)
+    assert torch.equal(norm_embeds[st.attractor_indices], stream.attractor_feats)
+    # Assignments index into the attractor pool.
+    assert int(st.train_assign.max()) < st.attractor_indices.numel()
+    assert int(st.held_assign.max()) < st.attractor_indices.numel()
+
+    # 2. Repeated access is stable (equal values each time).
+    st2 = stream.selection_state
+    for f in ("train_indices", "held_indices", "attractor_indices",
+              "train_assign", "held_assign"):
+        assert torch.equal(getattr(st, f), getattr(st2, f))
+
+    # 3. Mutating returned tensors does not mutate the stream (clone, not alias).
+    snap_train = stream._train_indices.clone()
+    snap_held = stream._held_indices.clone()
+    snap_aidx = stream._attractor_indices.clone()
+    snap_tassign = stream._train_assign.clone()
+    snap_hassign = stream._held_assign.clone()
+    st.train_indices[0] = 9999
+    st.held_indices[0] = 9999
+    st.attractor_indices[0] = 9999
+    st.train_assign[0] = 9999
+    st.held_assign[0] = 9999
+    assert torch.equal(stream._train_indices, snap_train)
+    assert torch.equal(stream._held_indices, snap_held)
+    assert torch.equal(stream._attractor_indices, snap_aidx)
+    assert torch.equal(stream._train_assign, snap_tassign)
+    assert torch.equal(stream._held_assign, snap_hassign)
+    # A fresh snapshot is unaffected by the mutation of the prior one.
+    st3 = stream.selection_state
+    assert torch.equal(st3.train_indices, snap_train)
+    assert torch.equal(st3.train_assign, snap_tassign)
+
+    # 4. The snapshot itself is frozen (dataclass(frozen=True)) — cannot rebind.
+    try:
+        st.train_indices = torch.zeros(1)
+        raise AssertionError("expected frozen dataclass to reject field rebind")
+    except Exception as e:  # FrozenInstanceError
+        assert "Frozen" in type(e).__name__ or "frozen" in str(e).lower()


### PR DESCRIPTION
## Scaffolding only — read-only accessor, no pilot

Small scaffolding PR ahead of the A2b `ReembedDriftStream` pilot. Adds the read-only/frozen **selection-state exposure** that the merged design note (PR #90, §2) requires `VisionDriftStream` to provide, so the paired-path re-embed arm can replay the *exact same* cache rows without recomputing RNG/selection/assignment.

### What this adds
- `VisionSelectionState` — a `@dataclass(frozen=True)` snapshot.
- `VisionDriftStream` now stores the selected cache-row indices at construction (`_train_indices`, `_held_indices`, `_attractor_indices`; `_train_assign`/`_held_assign` already existed) and exposes them via a read-only `selection_state` property that returns **cloned** tensors.
- `tests/test_vision_selection_state.py` — one focused test (synthetic `.pt` cache, no host cache needed).

### Why now
Per the [follow-on base-branch rule] this is branched off updated `main` (post PR #90 merge). The design explicitly required this accessor come from `VisionDriftStream`; isolating it as scaffolding keeps the later pilot mechanical.

### What it pins (test)
- Exposed indices/assignments equal the internally selected ones, and genuinely address the selected rows in the same order as `train_X`/`held_X`/`attractor_feats`.
- Repeated `selection_state` access is stable.
- Mutating returned tensors does not mutate the stream (clone, not alias); the snapshot is frozen.

### Explicitly NOT in this PR
- No `ReembedDriftStream` implementation.
- No image loading / no real ImageNet-R cache use.
- No G1/G2 pilot, no experiment, no run.
- No change to `forward()`, `associative_core.py`, the detector, analyzers, `calibration_probe.py`, or existing result files.
- No change to selection behavior or the public run schema (additive accessor only; storing already-computed indices, no new/reordered RNG draws).

### Verification
- `python -m pytest tests/test_vision_selection_state.py tests/test_probe_telemetry.py -q` → 7 passed.
- `git diff --stat` vs main: 2 files, +162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)