### PR TITLE
Add ReembedDriftStream pilot gates

### DIFF
--- a/benchmarks/reembed_drift_stream.py
+++ b/benchmarks/reembed_drift_stream.py
@@ -1,0 +1,267 @@
+"""A2b · ``ReembedDriftStream`` — input-level (pixel cross-fade) re-embedding arm.
+
+Pilot scaffolding only. This stream is the paired-path counterpart to
+``VisionDriftStream``: it replays the **same** endpoint pairs and the **same**
+per-sample attractor assignment, but interpolates in *pixel* space and
+re-embeds through the model, instead of linearly blending cached features. The
+only thing that differs from the cache-linear arm is the interpolation space
+(pixels vs embeddings) — see
+``results/issue_input_reembed_fidelity/REEMBED_DRIFT_STREAM_DESIGN.md``.
+
+Design constraints honoured here:
+
+* **Consumes, never re-derives, the selection.** Construction reads
+  ``vision_stream.selection_state`` (cloned ``train``/``held``/``attractor``
+  rows + the two assignment tensors) and the vision stream's labels. It takes
+  no class list, seed, or split logic, so it is structurally incapable of
+  recomputing RNG / class selection / assignment.
+* **Raw model output to the engine.** ``batch(c)`` returns the raw DINOv2
+  output (no unit-normalisation); unit norms appear only inside the cosine /
+  path-divergence diagnostics below.
+* **resize → crop → ToTensor → blend in [0,1] → Normalize → model.** The pixel
+  cross-fade happens on the ``[0,1]`` cropped tensors, *before* ``Normalize``,
+  which preserves byte-identical endpoint geometry at ``c=0`` / ``c=1``.
+
+The heavy pieces (torchvision ``ImageFolder``, the live DINOv2 model) are
+**injected**, never imported at module load, so the gate logic is unit-testable
+with a fake model over a synthetic cache. The real wiring lives in
+``ReembedDriftStream.from_extractor``.
+
+This module does **not** touch ``forward()``, ``associative_core.py``, the
+detector, retrieval, or ``VisionDriftStream``. It runs no calibration / subset
+experiment; it exists to validate the pilot gates (see ``probe_reembed_pilot``).
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+# Pilot gate thresholds (see REEMBED_DRIFT_STREAM_DESIGN.md §4/§6).
+G1_COS_THRESHOLD = 0.999   # endpoint identity: cos(reembed@c, cached endpoint) must exceed this
+G2_MIN_DIVERGENCE = 1e-3   # mid-path divergence below this is "trivial" -> INCONCLUSIVE
+
+
+def split_transform(compose):
+    """Split a ``Resize→CenterCrop→ToTensor→Normalize`` Compose into two stages.
+
+    Returns ``(geometry, normalize)`` where ``geometry`` maps a PIL image to a
+    cropped ``[0,1]`` CHW tensor (everything up to and including ``ToTensor``)
+    and ``normalize`` applies the trailing ``Normalize``. The split point is the
+    single ``Normalize`` in the pipeline; this is what lets the pixel cross-fade
+    happen in ``[0,1]`` space before mean/std standardisation.
+    """
+    import torchvision.transforms as T
+
+    ts = list(compose.transforms)
+    norm_positions = [i for i, t in enumerate(ts) if isinstance(t, T.Normalize)]
+    if len(norm_positions) != 1:
+        raise ValueError(
+            "expected exactly one torchvision Normalize in the transform "
+            f"(the [0,1]->standardised split point), found {len(norm_positions)}")
+    i = norm_positions[0]
+    return T.Compose(ts[:i]), T.Compose(ts[i:])
+
+
+class ReembedDriftStream:
+    """Drop-in for ``VisionDriftStream.batch`` that re-embeds pixel cross-fades.
+
+    Construct via :meth:`from_extractor` for the real ImageNet-R / DINOv2 wiring,
+    or directly (with injected ``image_for_row`` / ``geom_transform`` /
+    ``normalize`` / ``model``) for tests.
+    """
+
+    def __init__(self, vision_stream, *, image_for_row, geom_transform,
+                 normalize, model, device="cpu"):
+        # --- Consume the vision stream's selection verbatim (clones, no recompute) ---
+        st = vision_stream.selection_state
+        self.train_indices = st.train_indices.clone()
+        self.held_indices = st.held_indices.clone()
+        self.attractor_indices = st.attractor_indices.clone()
+        self.train_assign = st.train_assign.clone()
+        self.held_assign = st.held_assign.clone()
+        # Shape/label parity straight off the vision stream — not re-derived.
+        self.train_lab = vision_stream.train_lab.clone()
+        self.held_lab = vision_stream.held_lab.clone()
+        self.num_classes = vision_stream.num_classes
+
+        self._image_for_row = image_for_row
+        self._geom = geom_transform
+        self._normalize = normalize
+        self._model = model
+        self._device = device
+        self._geom_cache: dict[int, torch.Tensor] = {}
+
+    # -- real wiring ---------------------------------------------------------
+    @classmethod
+    def from_extractor(cls, vision_stream, extractor, model, *,
+                       device="cpu", split="train"):
+        """Wire ``image_for_row`` / transforms from the cache's own extractor.
+
+        Uses the extractor module that built the cache as the single source of
+        truth for the dataset root, stratified split, loader, and transform —
+        nothing is reimplemented from memory (mirrors the merged G0/G1 probe).
+        """
+        from torchvision.datasets import ImageFolder
+
+        full_ds = ImageFolder(root=extractor.DATASET_ROOT, transform=None)
+        train_sub, test_sub = extractor.stratified_split(
+            full_ds, extractor.TRAIN_RATIO, extractor.SEED)
+        sub = train_sub if split == "train" else test_sub
+        split_indices = sub.indices            # cache row i -> full_ds[split_indices[i]]
+        loader = full_ds.loader
+        samples = full_ds.samples
+        geom, normalize = split_transform(extractor.build_transform())
+
+        # Force the real model into the expected inference state. Only here, in
+        # the real-wiring path — direct __init__ stays untouched so tests can
+        # inject fake (non-Module) models without an .eval()/.to() surface.
+        model = model.to(device).eval()
+
+        def image_for_row(row: int):
+            ds_idx = split_indices[int(row)]
+            path = samples[ds_idx][0]
+            return loader(path)
+
+        return cls(vision_stream, image_for_row=image_for_row,
+                   geom_transform=geom, normalize=normalize,
+                   model=model, device=device)
+
+    # -- per-step behaviour --------------------------------------------------
+    def _geom_for_row(self, row: int) -> torch.Tensor:
+        """Cropped ``[0,1]`` CHW tensor for a cache row (cached; deterministic)."""
+        r = int(row)
+        if r not in self._geom_cache:
+            self._geom_cache[r] = self._geom(self._image_for_row(r))
+        return self._geom_cache[r]
+
+    def _embed_blend(self, sample_rows: torch.Tensor, assign: torch.Tensor,
+                     contraction: float) -> torch.Tensor:
+        """Raw embeddings of the pixel cross-fade for one pool at contraction c.
+
+        For sample row ``s`` assigned to attractor pool slot ``a`` (-> attractor
+        cache row ``attractor_indices[a]``):
+        ``img(c) = (1-c)·geom(s) + c·geom(attractor)`` in ``[0,1]``, then
+        ``Normalize``, then ``model`` — returned raw (no unit normalisation).
+        """
+        c = float(contraction)
+        imgs = []
+        for s, a in zip(sample_rows.tolist(), assign.tolist()):
+            arow = int(self.attractor_indices[a])
+            gx = self._geom_for_row(s)
+            ga = self._geom_for_row(arow)
+            blended = (1.0 - c) * gx + c * ga      # pixel cross-fade in [0,1]
+            imgs.append(self._normalize(blended))
+        batch = torch.stack(imgs).to(self._device)
+        with torch.no_grad():
+            emb = self._model(batch)
+        return emb.detach().cpu().float()          # RAW output to the engine
+
+    def batch(self, contraction: float):
+        """``VisionDriftStream``-shaped yield: ``(train_q, train_y, train_lab), (held_q, held_lab)``.
+
+        ``train_q`` / ``held_q`` are RAW re-embeddings of the pixel cross-fade.
+        """
+        train_q = self._embed_blend(self.train_indices, self.train_assign, contraction)
+        held_q = self._embed_blend(self.held_indices, self.held_assign, contraction)
+        train_y = F.one_hot(self.train_lab, num_classes=self.num_classes).float()
+        return (train_q, train_y, self.train_lab), (held_q, self.held_lab)
+
+
+# --------------------------------------------------------------------------
+# Pilot gates (pure diagnostics; consume both arms, mutate nothing)
+# --------------------------------------------------------------------------
+def assignment_parity(reembed: "ReembedDriftStream", vision) -> bool:
+    """True iff the reembed arm replays the vision arm's exact selection."""
+    st = vision.selection_state
+    return bool(
+        torch.equal(reembed.train_indices, st.train_indices)
+        and torch.equal(reembed.held_indices, st.held_indices)
+        and torch.equal(reembed.attractor_indices, st.attractor_indices)
+        and torch.equal(reembed.train_assign, st.train_assign)
+        and torch.equal(reembed.held_assign, st.held_assign))
+
+
+def g1_endpoint_min_cosine(reembed: "ReembedDriftStream", vision) -> float:
+    """Min cosine of reembed endpoints vs the cached endpoints the vision arm blends.
+
+    ``c=0`` -> sample endpoint (cached ``train_X`` / ``held_X``);
+    ``c=1`` -> attractor endpoint (cached ``attractor_feats[assign]``).
+    Cosine is norm-invariant; diagnostics normalize both sides before comparison.
+    """
+    st = vision.selection_state
+    (q0, _, _), (h0, _) = reembed.batch(0.0)
+    (q1, _, _), (h1, _) = reembed.batch(1.0)
+
+    def cos(a, b):
+        return F.cosine_similarity(F.normalize(a, dim=-1),
+                                   F.normalize(b, dim=-1), dim=-1)
+
+    cosines = torch.cat([
+        cos(q0, vision.train_X),
+        cos(h0, vision.held_X),
+        cos(q1, vision.attractor_feats[st.train_assign]),
+        cos(h1, vision.attractor_feats[st.held_assign]),
+    ])
+    return float(cosines.min())
+
+
+def g2_path_divergence(reembed: "ReembedDriftStream", vision,
+                       contractions=(0.25, 0.5, 0.75)) -> list[float]:
+    """Per-c max ``1 - cos(unit(q_linear), unit(q_reembed))`` over both pools.
+
+    Measures how far the input-level path departs from the cache-linear path at
+    each mid-contraction. Endpoints are shared (G1), so only ``0<c<1`` is probed.
+    """
+    divs = []
+    for c in contractions:
+        (qr, _, _), (hr, _) = reembed.batch(c)
+        (ql, _, _), (hl, _) = vision.batch(c)
+        d_tr = 1.0 - F.cosine_similarity(
+            F.normalize(qr, dim=-1), F.normalize(ql, dim=-1), dim=-1)
+        d_ho = 1.0 - F.cosine_similarity(
+            F.normalize(hr, dim=-1), F.normalize(hl, dim=-1), dim=-1)
+        divs.append(max(float(d_tr.max()), float(d_ho.max())))
+    return divs
+
+
+def pilot_verdict(reembed: "ReembedDriftStream", vision,
+                  contractions=(0.25, 0.5, 0.75)) -> dict:
+    """Run the three pilot gates and return a verdict dict.
+
+    Answers, in order:
+      1. parity preserved?            -> FAIL if not
+      2. c=0/c=1 cos > 0.999?         -> FAIL if not
+      3. mid-path diverges nontrivially? -> INCONCLUSIVE if not, else PASS
+    """
+    parity = assignment_parity(reembed, vision)
+    if not parity:
+        return {"verdict": "FAIL", "gate": "parity", "parity": False,
+                "reason": "assignment/endpoint parity broken vs VisionDriftStream; "
+                          "the paired comparison is void.",
+                "g1_min_cosine": None, "g2_divergence": None}
+
+    min_cos = g1_endpoint_min_cosine(reembed, vision)
+    if min_cos <= G1_COS_THRESHOLD:
+        return {"verdict": "FAIL", "gate": "g1_endpoint", "parity": True,
+                "g1_min_cosine": min_cos, "g2_divergence": None,
+                "reason": (f"endpoint cosine {min_cos:.6f} <= {G1_COS_THRESHOLD}; "
+                           "re-embed pipeline does not reproduce the cached "
+                           "endpoints. Do NOT loosen the threshold — diagnose the "
+                           "resize/crop/ToTensor/Normalize ordering.")}
+
+    divs = g2_path_divergence(reembed, vision, contractions)
+    max_div = max(divs)
+    if max_div <= G2_MIN_DIVERGENCE:
+        return {"verdict": "INCONCLUSIVE", "gate": "g2_divergence", "parity": True,
+                "g1_min_cosine": min_cos, "g2_divergence": divs,
+                "reason": (f"mid-path divergence max {max_div:.3e} <= "
+                           f"{G2_MIN_DIVERGENCE:.0e}; the input-level path is "
+                           "(near-)collinear with the cache-linear path. Mark "
+                           "INCONCLUSIVE and diagnose before any subset run.")}
+
+    return {"verdict": "PASS", "gate": None, "parity": True,
+            "g1_min_cosine": min_cos, "g2_divergence": divs,
+            "reason": (f"parity holds, endpoints reproduce (min cos {min_cos:.6f} "
+                       f"> {G1_COS_THRESHOLD}), and the input-level path diverges "
+                       f"nontrivially mid-path (max {max_div:.3e} > "
+                       f"{G2_MIN_DIVERGENCE:.0e}).")}

--- a/benchmarks/reembed_drift_stream.py
+++ b/benchmarks/reembed_drift_stream.py
@@ -235,7 +235,7 @@ def pilot_verdict(reembed: "ReembedDriftStream", vision,
     """
     parity = assignment_parity(reembed, vision)
     if not parity:
-        return {"verdict": "FAIL", "gate": "parity", "parity": False,
+        return {"verdict": "FAIL", "gate": "assignment_parity", "parity": False,
                 "reason": "assignment/endpoint parity broken vs VisionDriftStream; "
                           "the paired comparison is void.",
                 "g1_min_cosine": None, "g2_divergence": None}

--- a/probe_reembed_pilot.py
+++ b/probe_reembed_pilot.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""A2b · ReembedDriftStream pilot gates (host-only, analysis-only).
+
+Tiny paired-path pilot (1 class + 1 attractor, a handful of samples, a few `c`
+values) that validates ONLY the three build-time gates from
+`results/issue_input_reembed_fidelity/REEMBED_DRIFT_STREAM_DESIGN.md` §4/§6:
+
+  1. Assignment / endpoint parity with VisionDriftStream.
+  2. G1 — c=0 / c=1 reproduce the cached endpoints at cosine > 0.999.
+  3. G2 — the input-level (pixel cross-fade) path diverges nontrivially from the
+     cache-linear path mid-path. If it does not, the pilot is INCONCLUSIVE
+     (NOT a pass) and must be diagnosed before any subset run.
+
+It does NOT run the subset/full A2b experiment, touch forward()/
+associative_core.py/the detector/retrieval, or modify VisionDriftStream. It is a
+read-only consumer of the merged feature cache + the live DINOv2 model.
+
+Host-only: requires the ImageNet-R dataset, the DINOv2 ViT-L/14 weights, and the
+feature cache the extractor wrote. The gate *logic* is covered host-independently
+by tests/test_reembed_drift_stream.py.
+"""
+import argparse
+import json
+import os
+import socket
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "benchmarks"))
+
+import extract_imagenet_r_vitl14 as ex  # noqa: E402
+from probe_contraction import VisionDriftStream  # noqa: E402
+from reembed_drift_stream import (  # noqa: E402
+    G1_COS_THRESHOLD, G2_MIN_DIVERGENCE, ReembedDriftStream, pilot_verdict)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--split", default="train", choices=["train", "test"])
+    ap.add_argument("--category", type=int, default=166,
+                    help="single content class for the pilot")
+    ap.add_argument("--attractor", type=int, default=134,
+                    help="attractor class (must differ from --category)")
+    ap.add_argument("--samples-per-class", type=int, default=8)
+    ap.add_argument("--held-out-per-class", type=int, default=4)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--contractions", type=str, default="0.25,0.5,0.75",
+                    help="comma-separated mid-path c values for the G2 probe")
+    ap.add_argument("--command", default="", help="verbatim command (for the report)")
+    ap.add_argument("--out",
+                    default="results/issue_input_reembed_fidelity/REEMBED_PILOT.md")
+    args = ap.parse_args()
+
+    if args.category == args.attractor:
+        ap.error("--category and --attractor must differ")
+    contractions = tuple(float(x) for x in args.contractions.split(",") if x.strip())
+
+    host = socket.gethostname()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    cache_path = os.path.join(ex.CACHE_DIR, f"imagenetr_dinov2_{args.split}.pt")
+
+    # Cache-linear arm.
+    vision = VisionDriftStream(
+        categories=[args.category], attractor_category=args.attractor,
+        samples_per_class=args.samples_per_class,
+        held_out_per_class=args.held_out_per_class,
+        seed=args.seed, cache_path=cache_path)
+
+    # Live model + input-level arm (replays the SAME selection through pixels).
+    model = torch.hub.load("facebookresearch/dinov2", "dinov2_vitl14")
+    model = model.to(device).eval()
+    reembed = ReembedDriftStream.from_extractor(
+        vision, ex, model, device=device, split=args.split)
+
+    verdict = pilot_verdict(reembed, vision, contractions=contractions)
+
+    summary = {
+        "verdict": verdict["verdict"], "gate": verdict["gate"],
+        "reason": verdict["reason"], "host": host, "device": str(device),
+        "cache_path": cache_path, "split": args.split,
+        "category": args.category, "attractor": args.attractor,
+        "samples_per_class": args.samples_per_class,
+        "held_out_per_class": args.held_out_per_class, "seed": args.seed,
+        "contractions": list(contractions),
+        "parity": verdict["parity"],
+        "g1_min_cosine": verdict["g1_min_cosine"],
+        "g1_threshold": G1_COS_THRESHOLD,
+        "g2_divergence_per_c": verdict["g2_divergence"],
+        "g2_min_divergence": G2_MIN_DIVERGENCE,
+    }
+    print(json.dumps(summary, indent=2))
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    g2 = verdict["g2_divergence"]
+    g2_str = ", ".join(f"c={c}: {d:.3e}" for c, d in zip(contractions, g2)) if g2 else "n/a"
+    g1_str = f"{verdict['g1_min_cosine']:.6f}" if verdict["g1_min_cosine"] is not None else "n/a"
+    lines = [
+        "# A2b · ReembedDriftStream pilot gates\n",
+        f"**Verdict: {verdict['verdict']}**"
+        f"{f' (gate: {verdict['gate']})' if verdict['gate'] else ''}\n",
+        f"_{verdict['reason']}_\n",
+        "## Run metadata\n",
+        f"- Host: `{host}` · Device: `{device}`",
+        f"- Command: `{args.command}`",
+        f"- Cache: `{cache_path}` (split=`{args.split}`)",
+        "- Model: `torch.hub facebookresearch/dinov2 :: dinov2_vitl14`",
+        f"- Pilot: class {args.category} + attractor {args.attractor}, "
+        f"{args.samples_per_class} train / {args.held_out_per_class} held, seed={args.seed}",
+        f"- Split/transform source of truth: `extract_imagenet_r_vitl14` "
+        f"(SEED={ex.SEED}, train_ratio={ex.TRAIN_RATIO})\n",
+        "## Gate results\n",
+        f"- **Parity** (same endpoints + assignment as VisionDriftStream): "
+        f"{'OK' if verdict['parity'] else 'BROKEN'}",
+        f"- **G1** endpoint identity (c=0/c=1): min cosine {g1_str} "
+        f"(threshold > {G1_COS_THRESHOLD})",
+        f"- **G2** mid-path divergence vs cache-linear: {g2_str} "
+        f"(nontrivial > {G2_MIN_DIVERGENCE:.0e})\n",
+        "## What this answers\n",
+        "1. Parity preserved? — see Parity above.",
+        "2. c=0/c=1 reproduce cached endpoints at cos > 0.999? — see G1.",
+        "3. Input-level path diverges nontrivially mid-path? — see G2.",
+        "4. If not, marked INCONCLUSIVE (not PASS). — see Verdict.\n",
+        "## Next-step decision\n",
+    ]
+    if verdict["verdict"] == "PASS":
+        lines.append("- ✅ Gates pass. Proceed to the 3-class subset run "
+                     "(separate, authorized step).")
+    elif verdict["verdict"] == "INCONCLUSIVE":
+        lines.append("- ⏸ INCONCLUSIVE. Do NOT proceed to the subset. Diagnose why "
+                     "the input-level path is collinear with the cache-linear path.")
+    else:
+        lines.append("- ⛔ FAIL. Stop and diagnose per the reason above before any "
+                     "further work.")
+    lines.append("")
+    with open(args.out, "w") as f:
+        f.write("\n".join(lines))
+    print(f"\nWrote {args.out}", file=sys.stderr)
+
+    # Non-zero exit on non-PASS so a CI/automation caller cannot mistake an
+    # INCONCLUSIVE/FAIL pilot for a green light.
+    sys.exit(0 if verdict["verdict"] == "PASS" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reembed_drift_stream.py
+++ b/tests/test_reembed_drift_stream.py
@@ -287,4 +287,4 @@ def test_parity_break_fails(tmp_path):
 
     verdict = pilot_verdict(reembed, vision)
     assert verdict["verdict"] == "FAIL"
-    assert verdict["gate"] == "parity"
+    assert verdict["gate"] == "assignment_parity"

--- a/tests/test_reembed_drift_stream.py
+++ b/tests/test_reembed_drift_stream.py
@@ -1,0 +1,268 @@
+"""Pilot gates for the A2b ``ReembedDriftStream`` (input-level re-embedding arm).
+
+These pin the four questions the pilot must answer, using a fake model over a
+tiny synthetic cache (no DINOv2, no ImageNet-R) so they run on any host:
+
+  1. Selection consumption, not recomputation — the stream replays the exact
+     tensors ``VisionDriftStream.selection_state`` hands it, even values no
+     seeded RNG would produce, and clones them.
+  2. Assignment / endpoint parity with ``VisionDriftStream``.
+  3. ``c=0`` / ``c=1`` reproduce the cached endpoints at cosine > 0.999, through
+     the real ``Resize→CenterCrop→ToTensor→blend in [0,1]→Normalize`` pipeline.
+  4. When the input-level path is (near-)collinear with the cache-linear path
+     (a linear model over the cross-fade), the verdict is INCONCLUSIVE, not PASS;
+     a nonlinear model that genuinely bends the path yields PASS.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torchvision.transforms as T
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "benchmarks"))
+
+from probe_contraction import VisionDriftStream, VisionSelectionState  # noqa: E402
+from reembed_drift_stream import (  # noqa: E402
+    G1_COS_THRESHOLD, ReembedDriftStream, assignment_parity,
+    g1_endpoint_min_cosine, g2_path_divergence, pilot_verdict, split_transform)
+
+CATEGORIES = [0, 1]
+ATTRACTOR = 2
+SAMPLES_PER_CLASS = 2
+HELD_PER_CLASS = 1
+PER_CLASS_CACHE = 5            # > samples+held; selection has something to choose
+SEED = 7
+CLASSES = CATEGORIES + [ATTRACTOR]
+N_ROWS = len(CLASSES) * PER_CLASS_CACHE
+
+
+def _labels():
+    labels = torch.empty(N_ROWS, dtype=torch.long)
+    for ci, cat in enumerate(CLASSES):
+        labels[ci * PER_CLASS_CACHE:(ci + 1) * PER_CLASS_CACHE] = cat
+    return labels
+
+
+# --------------------------------------------------------------------------
+# Real-pipeline fixture: tiny PIL images + a fixed model define the cache, so
+# re-embedding any selected row reproduces its cached vector exactly.
+# --------------------------------------------------------------------------
+SIZE = 8                      # post-crop spatial size
+DIM = 16                      # embedding dim
+_REAL_COMPOSE = T.Compose([
+    T.Resize(SIZE, interpolation=T.InterpolationMode.BICUBIC),
+    T.CenterCrop(SIZE),
+    T.ToTensor(),
+    T.Normalize(mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225)),
+])
+
+
+def _make_pil_images():
+    """N_ROWS deterministic small RGB PILs of varied size (exercises resize/crop)."""
+    g = torch.Generator().manual_seed(123)
+    imgs = []
+    for r in range(N_ROWS):
+        h = 10 + (r % 3)
+        w = 9 + ((r * 2) % 4)
+        arr = (torch.rand(h, w, 3, generator=g) * 255).to(torch.uint8).numpy()
+        imgs.append(Image.fromarray(arr, mode="RGB"))
+    return imgs
+
+
+def _linear_model(seed=99, out=DIM, in_dim=3 * SIZE * SIZE):
+    g = torch.Generator().manual_seed(seed)
+    W = torch.randn(out, in_dim, generator=g)
+
+    def model(batch):
+        return batch.flatten(1) @ W.T
+
+    return model
+
+
+def _nonlinear_model(seed=99, out=DIM, in_dim=3 * SIZE * SIZE):
+    g = torch.Generator().manual_seed(seed)
+    W = torch.randn(out, in_dim, generator=g)
+    V = torch.randn(out, in_dim, generator=g)
+
+    def model(batch):
+        x = batch.flatten(1)
+        # Quadratic term makes embed(pixel-blend) != linear blend of embeds,
+        # so the input-level path genuinely bends away from the cache-linear path.
+        return x @ W.T + (x * x) @ V.T
+
+    return model
+
+
+def _build_cache(tmp_path, model, geom, normalize, images):
+    """Save a {'embeds','labels'} cache whose row r == model(pipeline(images[r]))."""
+    embeds = torch.empty(N_ROWS, DIM)
+    with torch.no_grad():
+        for r in range(N_ROWS):
+            x = normalize(geom(images[r])).unsqueeze(0)
+            embeds[r] = model(x).squeeze(0)
+    cache = tmp_path / "synthetic_cache.pt"
+    torch.save({"embeds": embeds, "labels": _labels()}, cache)
+    return cache
+
+
+def _paired(tmp_path, model, geom, normalize, images):
+    cache = _build_cache(tmp_path, model, geom, normalize, images)
+    vision = VisionDriftStream(
+        categories=CATEGORIES, attractor_category=ATTRACTOR,
+        samples_per_class=SAMPLES_PER_CLASS, held_out_per_class=HELD_PER_CLASS,
+        seed=SEED, cache_path=str(cache))
+    reembed = ReembedDriftStream(
+        vision, image_for_row=lambda r: images[r],
+        geom_transform=geom, normalize=normalize, model=model)
+    return vision, reembed
+
+
+# --------------------------------------------------------------------------
+# 1. Consumption, not recomputation
+# --------------------------------------------------------------------------
+def test_consumes_selection_state_verbatim_and_clones():
+    # A fake vision stream exposing an *impossible* selection (non-contiguous,
+    # unsorted rows no seeded randperm over this cache would yield in this order).
+    train_idx = torch.tensor([97, 3, 55])
+    held_idx = torch.tensor([12, 800])
+    attr_idx = torch.tensor([41, 5, 63])
+    train_assign = torch.tensor([2, 0, 1])
+    held_assign = torch.tensor([1, 2])
+    st = VisionSelectionState(
+        train_indices=train_idx, held_indices=held_idx, attractor_indices=attr_idx,
+        train_assign=train_assign, held_assign=held_assign)
+    fake = SimpleNamespace(
+        selection_state=st,
+        train_lab=torch.tensor([0, 1, 0]), held_lab=torch.tensor([0, 1]),
+        num_classes=2)
+
+    # Construct using ONLY selection_state + labels (no seed / categories / cache).
+    reembed = ReembedDriftStream(
+        fake, image_for_row=lambda r: None,
+        geom_transform=lambda x: x, normalize=lambda x: x, model=lambda b: b)
+
+    assert torch.equal(reembed.train_indices, train_idx)
+    assert torch.equal(reembed.held_indices, held_idx)
+    assert torch.equal(reembed.attractor_indices, attr_idx)
+    assert torch.equal(reembed.train_assign, train_assign)
+    assert torch.equal(reembed.held_assign, held_assign)
+
+    # Clones, not aliases: mutating the stream must not touch the source tensors.
+    reembed.train_indices[0] = -1
+    reembed.train_assign[0] = -1
+    assert int(train_idx[0]) == 97
+    assert int(train_assign[0]) == 2
+
+
+# --------------------------------------------------------------------------
+# 2. Assignment / endpoint parity
+# --------------------------------------------------------------------------
+def test_assignment_parity(tmp_path):
+    images = _make_pil_images()
+    geom, normalize = split_transform(_REAL_COMPOSE)
+    vision, reembed = _paired(tmp_path, _linear_model(), geom, normalize, images)
+
+    assert assignment_parity(reembed, vision)
+    # ...and it really is the vision arm's selection.
+    st = vision.selection_state
+    assert torch.equal(reembed.train_indices, st.train_indices)
+    assert torch.equal(reembed.train_assign, st.train_assign)
+    assert torch.equal(reembed.attractor_indices, st.attractor_indices)
+
+    # A tampered assignment must be detected as a parity break.
+    reembed.train_assign[0] = (int(reembed.train_assign[0]) + 1) % reembed.attractor_indices.numel()
+    assert not assignment_parity(reembed, vision)
+
+
+# --------------------------------------------------------------------------
+# 3. c=0 / c=1 endpoint identity through the real pixel pipeline
+# --------------------------------------------------------------------------
+def test_endpoint_cosine_through_real_pipeline(tmp_path):
+    images = _make_pil_images()
+    geom, normalize = split_transform(_REAL_COMPOSE)
+    vision, reembed = _paired(tmp_path, _linear_model(), geom, normalize, images)
+
+    min_cos = g1_endpoint_min_cosine(reembed, vision)
+    assert min_cos > G1_COS_THRESHOLD, f"endpoint cosine {min_cos} <= {G1_COS_THRESHOLD}"
+
+    # c=0 reproduces the sample endpoint; c=1 the assigned attractor endpoint.
+    st = vision.selection_state
+    (q0, _, _), _ = reembed.batch(0.0)
+    (q1, _, _), _ = reembed.batch(1.0)
+    assert torch.allclose(F.normalize(q0, dim=-1),
+                          F.normalize(vision.train_X, dim=-1), atol=1e-5)
+    assert torch.allclose(F.normalize(q1, dim=-1),
+                          F.normalize(vision.attractor_feats[st.train_assign], dim=-1),
+                          atol=1e-5)
+
+
+def test_split_transform_orders_blend_before_normalize():
+    geom, normalize = split_transform(_REAL_COMPOSE)
+    img = _make_pil_images()[0]
+    g = geom(img)
+    # Geometry stage ends at ToTensor -> a [0,1] CHW float tensor.
+    assert g.shape == (3, SIZE, SIZE)
+    assert g.min() >= 0.0 and g.max() <= 1.0
+    # The single Normalize lives in the normalize stage and shifts out of [0,1].
+    n = normalize(g)
+    assert n.min() < 0.0
+
+
+# --------------------------------------------------------------------------
+# 4. Verdict logic: trivial divergence -> INCONCLUSIVE; bent path -> PASS
+# --------------------------------------------------------------------------
+def _identity_unit_fixture(tmp_path):
+    """Identity transforms + identity model + unit-norm endpoint 'pixels'.
+
+    A linear (identity) model maps the [0,1] convex cross-fade to a convex combo
+    in embedding space; equal-norm endpoints then make the input-level path
+    collinear with the cache-linear path -> trivial divergence.
+    """
+    g = torch.Generator().manual_seed(321)
+    vecs = [F.normalize(torch.randn(DIM, generator=g), dim=-1) for _ in range(N_ROWS)]
+    embeds = torch.stack(vecs)
+    cache = tmp_path / "identity_cache.pt"
+    torch.save({"embeds": embeds, "labels": _labels()}, cache)
+    vision = VisionDriftStream(
+        categories=CATEGORIES, attractor_category=ATTRACTOR,
+        samples_per_class=SAMPLES_PER_CLASS, held_out_per_class=HELD_PER_CLASS,
+        seed=SEED, cache_path=str(cache))
+    reembed = ReembedDriftStream(
+        vision, image_for_row=lambda r: vecs[r],
+        geom_transform=lambda x: x, normalize=lambda x: x, model=lambda b: b)
+    return vision, reembed
+
+
+def test_trivial_divergence_is_inconclusive_not_pass(tmp_path):
+    vision, reembed = _identity_unit_fixture(tmp_path)
+
+    # Parity and endpoints are fine; only the path is degenerate.
+    assert assignment_parity(reembed, vision)
+    assert g1_endpoint_min_cosine(reembed, vision) > G1_COS_THRESHOLD
+    divs = g2_path_divergence(reembed, vision)
+    assert max(divs) <= 1e-3, f"expected ~collinear path, got divergence {divs}"
+
+    verdict = pilot_verdict(reembed, vision)
+    assert verdict["verdict"] == "INCONCLUSIVE"
+    assert verdict["gate"] == "g2_divergence"
+
+
+def test_nonlinear_path_passes(tmp_path):
+    images = _make_pil_images()
+    geom, normalize = split_transform(_REAL_COMPOSE)
+    vision, reembed = _paired(tmp_path, _nonlinear_model(), geom, normalize, images)
+
+    # Endpoints still reproduce (cache == model(pipeline(image))), parity holds,
+    # and the quadratic model bends the mid-path away from the linear arm.
+    assert assignment_parity(reembed, vision)
+    assert g1_endpoint_min_cosine(reembed, vision) > G1_COS_THRESHOLD
+    divs = g2_path_divergence(reembed, vision)
+    assert max(divs) > 1e-3, f"nonlinear path should diverge, got {divs}"
+
+    verdict = pilot_verdict(reembed, vision)
+    assert verdict["verdict"] == "PASS"
+    assert verdict["gate"] is None

--- a/tests/test_reembed_drift_stream.py
+++ b/tests/test_reembed_drift_stream.py
@@ -266,3 +266,25 @@ def test_nonlinear_path_passes(tmp_path):
     verdict = pilot_verdict(reembed, vision)
     assert verdict["verdict"] == "PASS"
     assert verdict["gate"] is None
+
+
+# --------------------------------------------------------------------------
+# 5. Verdict logic: parity break -> FAIL
+# --------------------------------------------------------------------------
+def test_parity_break_fails(tmp_path):
+    images = _make_pil_images()
+    geom, normalize = split_transform(_REAL_COMPOSE)
+    vision, reembed = _paired(tmp_path, _linear_model(), geom, normalize, images)
+
+    # Sanity: starts as a valid stream.
+    assert assignment_parity(reembed, vision)
+
+    # Tamper: shift every train assignment by 1 mod the attractor pool size.
+    n_attr = reembed.attractor_indices.numel()
+    reembed.train_assign = (reembed.train_assign + 1) % n_attr
+
+    assert not assignment_parity(reembed, vision)
+
+    verdict = pilot_verdict(reembed, vision)
+    assert verdict["verdict"] == "FAIL"
+    assert verdict["gate"] == "parity"


### PR DESCRIPTION
- Implements only the A2b pilot-gate scaffolding.
- Adds `ReembedDriftStream`, a host-only pilot entrypoint, and focused tests.
- Does not run the real ImageNet-R/DINOv2 host pilot.
- Does not run the full A2b subset or calibration experiment.
- Does not change retrieval behavior, `forward()`, `associative_core.py`, detector logic, existing analyzers, or existing result files.
- Consumes `VisionDriftStream.selection_state` rather than recomputing assignment.
- Preserves raw DINOv2 outputs into the engine path; unit normalization is diagnostic-only.
- Enforces `model.to(device).eval()` in the real extractor wiring path.
- G1 failure returns FAIL; trivial G2 divergence returns INCONCLUSIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)